### PR TITLE
add opt-in for identifiable random generation.

### DIFF
--- a/config/main.yaml
+++ b/config/main.yaml
@@ -1,11 +1,13 @@
 # Dataset parameters
 seed: 0 # Random seed for reproducibility
-batch_size: 1 # Number of (img1, img2, flow) tuples per batch
-flow_fields_per_batch: 1 # Number of flow fields used for each batch
-batches_per_flow_batch: 1 # Number of batches of (imgs1, imgs2, flows) tuples per flow batch
+batch_size: 1 # Number of (img1, img2, flow) tuples per data batch
+flow_fields_per_batch: 1 # Number of unique flow fields per data batch
+batches_per_flow_batch: 1 # Number of consecutive batches of (imgs1, imgs2, flows) generated with each set of flow fields
 randomize: false # Whether to randomize the order of the files
 loop: true # Whether to loop through the files indefinitely
-device_ids: [0]
+identifiable_flow: false # Whether to allow identification of the flow generating that image
+device_ids: [0] # Indexes of the machine's visible device list that are selected.
+                # Omitt to select all avalable devices.
 
 # Image generation parameters
 image_shape: [1024, 1024] # Shape of the images to be generated

--- a/src/synthpix/make.py
+++ b/src/synthpix/make.py
@@ -101,6 +101,7 @@ def make_grain_scheduler(
     include_images: bool,
     randomize: bool,
     loop: bool,
+    identifiable_flow: bool,
 ) -> GrainEpisodicAdapter | GrainSchedulerAdapter:
     """Create a Grain-based scheduler.
 
@@ -112,6 +113,7 @@ def make_grain_scheduler(
         include_images: Whether to include images.
         randomize: Whether to randomize the data.
         loop: Whether to loop the data.
+        identifiable_flow: Whether used flow must be identifiable for the user.
 
     Returns:
         A Grain-based scheduler.
@@ -176,13 +178,21 @@ def make_grain_scheduler(
             "the number of workers is constant."
         )
 
+    # we add a deterministic seed to every record
+    if identifiable_flow:
+        operations = [
+            AddJAXSeed(),
+            grain.Batch(batch_size=batch_size, drop_remainder=False),
+        ]
+    else:
+        operations = [
+            grain.Batch(batch_size=batch_size, drop_remainder=False),
+        ]
+
     grain_loader = grain.DataLoader(
         data_source=data_source,
         sampler=sampler_grain,
-        operations=[
-            AddJAXSeed(),
-            grain.Batch(batch_size=batch_size, drop_remainder=False),
-        ],
+        operations=operations,
         worker_count=worker_count,
         read_options=grain.ReadOptions(
             num_threads=num_threads, prefetch_buffer_size=buffer_size
@@ -351,32 +361,7 @@ def make(
             invalid.
         FileNotFoundError: If the configuration file doesn't exist.
     """
-    # Initialize console for colored output
-    console = Console()
-
-    # SynthPix Banner
-    banner = [
-        r"   ____              _   _     ____  _         ",
-        r"  / ___| _   _ _ __ | |_| |__ |  _ \(_)_  __   ",
-        r"  \___ \| | | | '_ \| __| '_ \| |_) | \ \/ /   ",
-        r"   ___) | |_| | | | | |_| | | |  __/| |>  <    ",
-        r"  |____/ \__, |_| |_|\__|_| |_|_|   |_/_/\_\   ",
-        r"         |___/                           ",
-    ]
-
-    # Define rainbow color cycle
-    rainbow_colors = ["red", "yellow", "green", "cyan", "blue", "magenta"]
-
-    # Print each line with cycling rainbow colors using Rich Text
-    for line in banner:
-        text = Text()
-        for idx, char in enumerate(line):
-            if char == " ":
-                text.append(char)
-            else:
-                color = rainbow_colors[idx % len(rainbow_colors)]
-                text.append(char, style=color)
-        console.print(text)
+    print_banner()
 
     # Input validation
     if not isinstance(config, str | dict):
@@ -443,6 +428,7 @@ def make(
         "loop": dataset_config.get("loop", True),
         "key": sched_key,
         "include_images": include_images,
+        "identifiable_flow": dataset_config.get("identifiable_flow", False),
     }
 
     if include_images:
@@ -468,6 +454,7 @@ def make(
             include_images=include_images,
             randomize=kwargs["randomize"],
             loop=kwargs["loop"],
+            identifiable_flow=kwargs["identifiable_flow"],
         )
 
     else:
@@ -584,3 +571,32 @@ def save_checkpoint(
     mngr.save(step=step, args=save_args)
     mngr.wait_until_finished()
     logger.info(f"Saved checkpoint to {checkpoint_dir} at step {step}")
+
+
+def print_banner():
+    # Initialize console for colored output
+    console = Console()
+
+    # SynthPix Banner
+    banner = [
+        r"   ____              _   _     ____  _         ",
+        r"  / ___| _   _ _ __ | |_| |__ |  _ \(_)_  __   ",
+        r"  \___ \| | | | '_ \| __| '_ \| |_) | \ \/ /   ",
+        r"   ___) | |_| | | | | |_| | | |  __/| |>  <    ",
+        r"  |____/ \__, |_| |_|\__|_| |_|_|   |_/_/\_\   ",
+        r"         |___/                           ",
+    ]
+
+    # Define rainbow color cycle
+    rainbow_colors = ["red", "yellow", "green", "cyan", "blue", "magenta"]
+
+    # Print each line with cycling rainbow colors using Rich Text
+    for line in banner:
+        text = Text()
+        for idx, char in enumerate(line):
+            if char == " ":
+                text.append(char)
+            else:
+                color = rainbow_colors[idx % len(rainbow_colors)]
+                text.append(char, style=color)
+        console.print(text)

--- a/src/synthpix/sampler/synthetic.py
+++ b/src/synthpix/sampler/synthetic.py
@@ -70,6 +70,7 @@ class SyntheticImageSampler(Sampler):
         generation_specification: ImageGenerationSpecification | None = None,
         mask_images: jnp.ndarray | None = None,
         histogram: jnp.ndarray | None = None,
+        identifiable_flow: bool = False,
     ):
         """Initializes the SyntheticImageSampler.
 
@@ -104,6 +105,9 @@ class SyntheticImageSampler(Sampler):
             histogram: Optional histogram to match during image generation.
                 Should be a jnp.ndarray of shape (256,).
                 NOTE: Histogram equalization is very slow!
+            identifiable_flow: Optional, makes sampled data batches' flows
+                identifiable for the downstream user.
+                NOTE: identifiable_flow is slow!
 
         Raises:
             ValueError: If parameters are invalid or incompatible.
@@ -271,6 +275,8 @@ class SyntheticImageSampler(Sampler):
                 "There will be one more sample for the first "
                 f"{extra_batch_size} flow fields of each batch."
             )
+
+        self.identifiable_flow = identifiable_flow
 
         # Check min and max speeds
         if not isinstance(max_speed_x, int | float):
@@ -532,7 +538,7 @@ class SyntheticImageSampler(Sampler):
             # batch)
             n_flows = (
                 len(self._jax_seeds)
-                if self._jax_seeds is not None
+                if (self.identifiable_flow and self._jax_seeds is not None)
                 else (
                     len(self._files_scheduler)
                     if self._files_scheduler is not None
@@ -576,7 +582,7 @@ class SyntheticImageSampler(Sampler):
                 self._current_flows.block_until_ready()
 
         # Generate keys
-        if self._jax_seeds is not None:
+        if self.identifiable_flow and self._jax_seeds is not None:
             # Grain Path: Use fold_in(record_seed, rep_idx)
             # record_seed is (B,) or (B, 2), rep_idx is int
 
@@ -638,7 +644,7 @@ class SyntheticImageSampler(Sampler):
                 else None
             ),
             seeds=jnp.array(self._jax_seeds)
-            if self._jax_seeds is not None
+            if (self.identifiable_flow and self._jax_seeds is not None)
             else None,
             keys=batch_keys,
         )
@@ -868,6 +874,7 @@ class SyntheticImageSampler(Sampler):
                 generation_specification=gs,
                 mask_images=mask_images,
                 histogram=histogram,
+                identifiable_flow=config["identifiable_flow"],
             )
         except KeyError as e:
             raise KeyError(


### PR DESCRIPTION
- now control flow of the sampler can be explicitly controlled from config.
- control flow of sampler is now independent on how the Scheduler was generated
- we kept for backward-compatibility the possibility of allowing to identify the flow that generated a batch.
[IMPORTANT] Code that relied on this faeature needs to adjust their config file to continue working. Code that didn't rely on this feature need not.