### PR TITLE
feat(hf): PR1/5 — Hugging Face Hub integration scaffold (auth, layout, dataset card)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,14 @@ download = [
     "tensorflow-cpu>=2.15.0",
 ]
 hf = [
-    "huggingface_hub[cli,hf_transfer]>=0.27",
+    "huggingface_hub>=0.27",
+    # huggingface_hub >= 1.0 dropped its ``[hf_transfer]`` extra (and
+    # ``[cli]`` is bundled into the core), so the accelerators must be
+    # declared directly to be installed reliably.
+    "hf_transfer>=0.1.6",
+    # ``hf-xet`` is hub 1.x's xet-backed transfer accelerator; activated
+    # automatically when importable.
+    "hf-xet>=0.1.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,12 @@ download = [
     "scipy>=1.10.0",
     "tensorflow-cpu>=2.15.0",
 ]
+hf = [
+    "huggingface_hub[cli,hf_transfer]>=0.27",
+]
+
+[project.scripts]
+synthpix-hf = "synthpix.hf.cli:main"
 
 
 # Pytest configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,10 @@ download = [
     "tensorflow-cpu>=2.15.0",
 ]
 hf = [
-    "huggingface_hub>=0.27",
+    # huggingface_hub 1.x dropped ``HfFolder`` in favor of the top-level
+    # ``get_token`` helper that ``auth._cached_token`` relies on, so the floor
+    # is pinned at 1.0 to keep cached-credential resolution working.
+    "huggingface_hub>=1.0",
     # huggingface_hub >= 1.0 dropped its ``[hf_transfer]`` extra (and
     # ``[cli]`` is bundled into the core), so the accelerators must be
     # declared directly to be installed reliably.

--- a/src/synthpix/hf/__init__.py
+++ b/src/synthpix/hf/__init__.py
@@ -1,0 +1,19 @@
+"""Hugging Face Hub integration for the ``synthpix`` package.
+
+This subpackage exposes only metadata and layout helpers in PR1. Network
+operations (push/pull) are deferred to subsequent PRs. ``huggingface_hub`` is
+imported lazily inside :mod:`synthpix.hf.auth`, so this module remains usable
+without the ``[hf]`` optional extra installed.
+"""
+
+from synthpix.hf.auth import resolve_token
+from synthpix.hf.card import DatasetCardMeta, make_dataset_card
+from synthpix.hf.layout import LayoutSummary, inspect_local_layout
+
+__all__ = [
+    "DatasetCardMeta",
+    "LayoutSummary",
+    "inspect_local_layout",
+    "make_dataset_card",
+    "resolve_token",
+]

--- a/src/synthpix/hf/auth.py
+++ b/src/synthpix/hf/auth.py
@@ -1,0 +1,60 @@
+"""Hugging Face Hub authentication helpers.
+
+The functions defined here read tokens from a small number of well-known
+locations without ever persisting them. ``huggingface_hub`` is imported lazily
+so that the rest of the ``synthpix.hf`` package remains importable without the
+``[hf]`` extra installed.
+"""
+
+from __future__ import annotations
+
+import os
+
+from synthpix.utils import SYNTHPIX_SCOPE, get_logger
+
+logger = get_logger(__name__, scope=SYNTHPIX_SCOPE)
+
+
+def _cached_token() -> str | None:
+    """Read the cached token via ``huggingface_hub`` if it is importable.
+
+    Returns:
+        str | None: The cached token, or ``None`` if the library is not
+            installed or no token is cached.
+    """
+    try:
+        from huggingface_hub import HfFolder
+    except ImportError:
+        logger.debug(
+            "huggingface_hub is not installed; skipping cached token lookup."
+        )
+        return None
+
+    token: str | None = HfFolder.get_token()
+    if token:
+        return token
+    return None
+
+
+def resolve_token(explicit: str | None = None) -> str | None:
+    """Resolve a Hugging Face token from the first available source.
+
+    The lookup order is: explicit argument, ``HF_TOKEN``, ``HF_HUB_TOKEN``,
+    and finally the cached token managed by ``huggingface_hub``. Empty strings
+    are treated as missing values. The function never writes to disk.
+
+    Args:
+        explicit: Token passed directly by the caller, if any.
+
+    Returns:
+        str | None: The first non-empty token found, or ``None`` if nothing
+            could be resolved.
+    """
+    if explicit:
+        return explicit
+
+    env_token = os.environ.get("HF_TOKEN") or os.environ.get("HF_HUB_TOKEN")
+    if env_token:
+        return env_token
+
+    return _cached_token()

--- a/src/synthpix/hf/auth.py
+++ b/src/synthpix/hf/auth.py
@@ -23,14 +23,24 @@ def _cached_token() -> str | None:
             installed or no token is cached.
     """
     try:
-        from huggingface_hub import HfFolder
+        import huggingface_hub  # noqa: PLC0415
     except ImportError:
         logger.debug(
             "huggingface_hub is not installed; skipping cached token lookup."
         )
         return None
 
-    token: str | None = HfFolder.get_token()
+    # huggingface_hub >= 1.0 removed ``HfFolder``; the cached CLI token is
+    # now read via the top-level ``get_token`` helper. Guard for older
+    # releases (and partially-stubbed installs) without re-raising.
+    get_token = getattr(huggingface_hub, "get_token", None)
+    if get_token is None:
+        logger.debug(
+            "huggingface_hub has no get_token(); skipping cached token lookup."
+        )
+        return None
+
+    token: str | None = get_token()
     if token:
         return token
     return None

--- a/src/synthpix/hf/card.py
+++ b/src/synthpix/hf/card.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import io
+import re
 import subprocess  # nosec B404 - used for read-only `git rev-parse`
 from dataclasses import dataclass, field
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+from ruamel.yaml import YAML
 
 from synthpix.hf.layout import LayoutSummary
 
@@ -46,7 +51,12 @@ class DatasetCardMeta:
 
 
 def _lookup_synthpix_version() -> str | None:
-    """Look up the installed ``synthpix`` version, if any."""
+    """Look up the installed ``synthpix`` version, if any.
+
+    Returns:
+        str | None: The package version from ``importlib.metadata``, or
+            ``None`` when ``synthpix`` is not installed.
+    """
     try:
         return version("synthpix")
     except PackageNotFoundError:
@@ -54,10 +64,23 @@ def _lookup_synthpix_version() -> str | None:
 
 
 def _lookup_git_commit() -> str | None:
-    """Return the current git commit, or ``None`` if unavailable."""
+    """Return the current synthpix-source git commit, if available.
+
+    The commit is resolved relative to the installed ``synthpix`` package
+    location (``Path(__file__).parent``) rather than the process working
+    directory, so the recorded value always describes the synthpix tree the
+    card was generated against — never an unrelated user project that happens
+    to be the CWD at invocation time. When synthpix is installed from a wheel
+    (no surrounding ``.git``), this returns ``None``.
+
+    Returns:
+        str | None: The full commit SHA, or ``None`` when ``git`` is missing
+            or the synthpix package is not inside a git checkout.
+    """
     try:
         output = subprocess.check_output(  # nosec B603 B607
             ["git", "rev-parse", "HEAD"],
+            cwd=str(Path(__file__).resolve().parent),
             stderr=subprocess.DEVNULL,
         )
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):
@@ -66,7 +89,15 @@ def _lookup_git_commit() -> str | None:
 
 
 def _resolved_meta(meta: DatasetCardMeta) -> DatasetCardMeta:
-    """Return a copy of ``meta`` with auto-fillable fields populated."""
+    """Return a copy of ``meta`` with auto-fillable fields populated.
+
+    Args:
+        meta: Caller-supplied metadata; ``synthpix_version`` /
+            ``synthpix_commit`` are filled in when left as ``None``.
+
+    Returns:
+        DatasetCardMeta: A new instance with provenance fields resolved.
+    """
     synthpix_version = meta.synthpix_version
     if synthpix_version is None:
         synthpix_version = _lookup_synthpix_version()
@@ -88,22 +119,32 @@ def _resolved_meta(meta: DatasetCardMeta) -> DatasetCardMeta:
     )
 
 
-def _format_tags(tags: tuple[str, ...]) -> str:
-    quoted = ", ".join(f"\"{tag}\"" for tag in tags)
-    return f"[{quoted}]"
-
-
 def _frontmatter(meta: DatasetCardMeta) -> str:
+    """Serialize the YAML frontmatter block via ``ruamel.yaml``.
+
+    Using a real YAML serializer (instead of string interpolation) means
+    embedded quotes, backslashes, colons or newlines in ``pretty_name`` or
+    ``tags`` cannot produce malformed frontmatter that fails to parse on the
+    Hub.
+
+    Args:
+        meta: Resolved card metadata to serialize.
+
+    Returns:
+        str: A ``---``-delimited YAML block, no trailing newline.
+    """
     pretty = meta.pretty_name or meta.name
-    lines = [
-        "---",
-        f"license: {meta.license}",
-        f"license_name: {meta.license_name}",
-        f"pretty_name: \"{pretty}\"",
-        f"tags: {_format_tags(meta.tags)}",
-        "---",
-    ]
-    return "\n".join(lines)
+    payload = {
+        "license": meta.license,
+        "license_name": meta.license_name,
+        "pretty_name": pretty,
+        "tags": list(meta.tags),
+    }
+    yaml = YAML(typ="safe", pure=True)
+    yaml.default_flow_style = False
+    buf = io.StringIO()
+    yaml.dump(payload, buf)
+    return "---\n" + buf.getvalue().rstrip("\n") + "\n---"
 
 
 def _split_table(layout: LayoutSummary) -> str:
@@ -119,7 +160,7 @@ def _split_table(layout: LayoutSummary) -> str:
 def _reynolds_section(layout: LayoutSummary) -> str:
     populated = {
         split: names
-        for split, names in layout.reynolds_by_split.items()
+        for split, names in layout.subdirs_by_split.items()
         if names
     }
     if not populated:
@@ -131,6 +172,26 @@ def _reynolds_section(layout: LayoutSummary) -> str:
     for split, names in populated.items():
         lines.append(f"| {split} | {', '.join(names)} |")
     return "\n".join(lines)
+
+
+def _fence_for(text: str) -> str:
+    """Return a backtick fence longer than the longest run inside ``text``.
+
+    Citation strings can legitimately contain triple-backtick code blocks; a
+    naive fixed ```` ``` ```` fence around the citation would terminate
+    prematurely. We scan for the longest run of backticks in the input and
+    pick a fence one longer (minimum length 3).
+
+    Args:
+        text: Content that will sit between the returned fence markers.
+
+    Returns:
+        str: A backtick string of length ``max(3, longest_run + 1)``.
+    """
+    longest = max(
+        (len(m.group(0)) for m in re.finditer(r"`+", text)), default=0
+    )
+    return "`" * max(3, longest + 1)
 
 
 def _provenance(meta: DatasetCardMeta) -> str:
@@ -145,9 +206,7 @@ def _provenance(meta: DatasetCardMeta) -> str:
     return f"\nGenerated with {joined}.\n"
 
 
-def make_dataset_card(
-    meta: DatasetCardMeta, layout: LayoutSummary
-) -> str:
+def make_dataset_card(meta: DatasetCardMeta, layout: LayoutSummary) -> str:
     """Render a Hugging Face dataset card README for ``meta`` and ``layout``.
 
     Args:
@@ -161,6 +220,7 @@ def make_dataset_card(
     """
     resolved = _resolved_meta(meta)
     pretty = resolved.pretty_name or resolved.name
+    fence = _fence_for(resolved.citation)
 
     sections = [
         _frontmatter(resolved),
@@ -171,9 +231,9 @@ def make_dataset_card(
         "",
         "## Citation",
         "",
-        "```",
+        fence,
         resolved.citation,
-        "```",
+        fence,
         "",
         "## License",
         "",

--- a/src/synthpix/hf/card.py
+++ b/src/synthpix/hf/card.py
@@ -22,22 +22,7 @@ _DEFAULT_TAGS: tuple[str, ...] = ("PIV", "synthetic", "optical-flow")
 
 @dataclass
 class DatasetCardMeta:
-    """User-facing metadata for a synthpix-hosted dataset card.
-
-    Attributes:
-        name: Repository-style short name of the dataset.
-        source_url: URL of the original dataset.
-        citation: BibTeX or free-form citation text.
-        license: SPDX-like license identifier exposed in the YAML frontmatter.
-        license_name: Optional license display name.
-        synthpix_version: Version of ``synthpix`` used to produce the card.
-            Auto-filled from ``importlib.metadata`` when left as ``None``.
-        synthpix_commit: Git commit of the working tree where the card was
-            generated. Auto-filled via ``git rev-parse HEAD`` when possible;
-            stays ``None`` outside a repository.
-        pretty_name: Display name used in the H1 heading and frontmatter.
-        tags: Hub tags exposed in the YAML frontmatter.
-    """
+    """User-facing metadata for a synthpix-hosted dataset card."""
 
     name: str
     source_url: str

--- a/src/synthpix/hf/card.py
+++ b/src/synthpix/hf/card.py
@@ -1,0 +1,194 @@
+"""Dataset card generation for synthpix-hosted PIV datasets."""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404 - used for read-only `git rev-parse`
+from dataclasses import dataclass, field
+from importlib.metadata import PackageNotFoundError, version
+
+from synthpix.hf.layout import LayoutSummary
+
+_LICENSE_NOTE = (
+    "This dataset is hosted under terms set by the original authors. "
+    "See source URL for details."
+)
+_DEFAULT_TAGS: tuple[str, ...] = ("PIV", "synthetic", "optical-flow")
+
+
+@dataclass
+class DatasetCardMeta:
+    """User-facing metadata for a synthpix-hosted dataset card.
+
+    Attributes:
+        name: Repository-style short name of the dataset.
+        source_url: URL of the original dataset.
+        citation: BibTeX or free-form citation text.
+        license: SPDX-like license identifier exposed in the YAML frontmatter.
+        license_name: Optional license display name.
+        synthpix_version: Version of ``synthpix`` used to produce the card.
+            Auto-filled from ``importlib.metadata`` when left as ``None``.
+        synthpix_commit: Git commit of the working tree where the card was
+            generated. Auto-filled via ``git rev-parse HEAD`` when possible;
+            stays ``None`` outside a repository.
+        pretty_name: Display name used in the H1 heading and frontmatter.
+        tags: Hub tags exposed in the YAML frontmatter.
+    """
+
+    name: str
+    source_url: str
+    citation: str
+    license: str = "other"
+    license_name: str = "research-only-arr"
+    synthpix_version: str | None = None
+    synthpix_commit: str | None = None
+    pretty_name: str | None = None
+    tags: tuple[str, ...] = field(default_factory=lambda: _DEFAULT_TAGS)
+
+
+def _lookup_synthpix_version() -> str | None:
+    """Look up the installed ``synthpix`` version, if any."""
+    try:
+        return version("synthpix")
+    except PackageNotFoundError:
+        return None
+
+
+def _lookup_git_commit() -> str | None:
+    """Return the current git commit, or ``None`` if unavailable."""
+    try:
+        output = subprocess.check_output(  # nosec B603 B607
+            ["git", "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+    return output.decode("utf-8").strip() or None
+
+
+def _resolved_meta(meta: DatasetCardMeta) -> DatasetCardMeta:
+    """Return a copy of ``meta`` with auto-fillable fields populated."""
+    synthpix_version = meta.synthpix_version
+    if synthpix_version is None:
+        synthpix_version = _lookup_synthpix_version()
+
+    synthpix_commit = meta.synthpix_commit
+    if synthpix_commit is None:
+        synthpix_commit = _lookup_git_commit()
+
+    return DatasetCardMeta(
+        name=meta.name,
+        source_url=meta.source_url,
+        citation=meta.citation,
+        license=meta.license,
+        license_name=meta.license_name,
+        synthpix_version=synthpix_version,
+        synthpix_commit=synthpix_commit,
+        pretty_name=meta.pretty_name,
+        tags=meta.tags,
+    )
+
+
+def _format_tags(tags: tuple[str, ...]) -> str:
+    quoted = ", ".join(f"\"{tag}\"" for tag in tags)
+    return f"[{quoted}]"
+
+
+def _frontmatter(meta: DatasetCardMeta) -> str:
+    pretty = meta.pretty_name or meta.name
+    lines = [
+        "---",
+        f"license: {meta.license}",
+        f"license_name: {meta.license_name}",
+        f"pretty_name: \"{pretty}\"",
+        f"tags: {_format_tags(meta.tags)}",
+        "---",
+    ]
+    return "\n".join(lines)
+
+
+def _split_table(layout: LayoutSummary) -> str:
+    if not layout.splits:
+        return "_No splits detected._"
+
+    rows = ["| Split | .mat files |", "| --- | --- |"]
+    for split, count in layout.splits.items():
+        rows.append(f"| {split} | {count} |")
+    return "\n".join(rows)
+
+
+def _reynolds_section(layout: LayoutSummary) -> str:
+    populated = {
+        split: names
+        for split, names in layout.reynolds_by_split.items()
+        if names
+    }
+    if not populated:
+        return ""
+
+    lines = ["", "### Reynolds / scenario subdirectories", ""]
+    lines.append("| Split | Subdirectories |")
+    lines.append("| --- | --- |")
+    for split, names in populated.items():
+        lines.append(f"| {split} | {', '.join(names)} |")
+    return "\n".join(lines)
+
+
+def _provenance(meta: DatasetCardMeta) -> str:
+    parts = []
+    if meta.synthpix_version:
+        parts.append(f"synthpix {meta.synthpix_version}")
+    if meta.synthpix_commit:
+        parts.append(f"commit `{meta.synthpix_commit}`")
+    if not parts:
+        return ""
+    joined = ", ".join(parts)
+    return f"\nGenerated with {joined}.\n"
+
+
+def make_dataset_card(
+    meta: DatasetCardMeta, layout: LayoutSummary
+) -> str:
+    """Render a Hugging Face dataset card README for ``meta`` and ``layout``.
+
+    Args:
+        meta: User-facing metadata. Auto-fillable fields
+            (``synthpix_version``, ``synthpix_commit``) are populated when
+            ``None``.
+        layout: Local layout summary used to render the split table.
+
+    Returns:
+        str: The rendered README content, starting with YAML frontmatter.
+    """
+    resolved = _resolved_meta(meta)
+    pretty = resolved.pretty_name or resolved.name
+
+    sections = [
+        _frontmatter(resolved),
+        "",
+        f"# {pretty}",
+        "",
+        f"Source: {resolved.source_url}",
+        "",
+        "## Citation",
+        "",
+        "```",
+        resolved.citation,
+        "```",
+        "",
+        "## License",
+        "",
+        _LICENSE_NOTE,
+        "",
+        "## Contents",
+        "",
+        _split_table(layout),
+    ]
+    reynolds = _reynolds_section(layout)
+    if reynolds:
+        sections.append(reynolds)
+
+    provenance = _provenance(resolved)
+    if provenance:
+        sections.append(provenance)
+
+    return "\n".join(sections).rstrip() + "\n"

--- a/src/synthpix/hf/cli.py
+++ b/src/synthpix/hf/cli.py
@@ -1,0 +1,117 @@
+"""Argparse entry point for the ``synthpix-hf`` console script."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from synthpix.hf.card import DatasetCardMeta, make_dataset_card
+from synthpix.hf.layout import inspect_local_layout
+from synthpix.utils import SYNTHPIX_SCOPE, get_logger
+
+logger = get_logger(__name__, scope=SYNTHPIX_SCOPE)
+
+_NOT_IMPLEMENTED = (
+    "This subcommand is not yet implemented in PR1. "
+    "Stay tuned for the upcoming push/pull rollouts."
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="synthpix-hf",
+        description=(
+            "Tooling for synthpix-hosted Hugging Face PIV datasets."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    card = sub.add_parser(
+        "card", help="Generate a dataset card README from a local layout."
+    )
+    card.add_argument("local_dir", type=Path)
+    card.add_argument("--source-url", required=True)
+    card.add_argument("--citation", required=True)
+    card.add_argument("--name", default=None)
+    card.add_argument("--pretty-name", default=None)
+    card.add_argument("--license", default="other")
+    card.add_argument("--license-name", default="research-only-arr")
+    card.add_argument("--output", type=Path, default=None)
+    card.add_argument("--force", action="store_true")
+
+    push = sub.add_parser("push", help="(PR2) Push a dataset to the Hub.")
+    push.add_argument("local_dir", nargs="?", default=None)
+    push.add_argument("--repo-id", default=None)
+
+    pull = sub.add_parser("pull", help="(PR3) Pull a dataset from the Hub.")
+    pull.add_argument("repo_id", nargs="?", default=None)
+    pull.add_argument("--local-dir", default=None)
+
+    return parser
+
+
+def _read_citation(value: str) -> str:
+    """Return the citation contents, reading from disk if ``value`` is a path."""
+    candidate = Path(value)
+    if candidate.is_file():
+        return candidate.read_text()
+    return value
+
+
+def _run_card(args: argparse.Namespace) -> int:
+    local_dir = args.local_dir
+    if not local_dir.is_dir():
+        logger.error(f"Local directory does not exist: {local_dir}")
+        return 2
+
+    output = args.output if args.output is not None else local_dir / "README.md"
+    if output.exists() and not args.force:
+        logger.error(f"Refusing to overwrite {output} without --force.")
+        return 1
+
+    layout = inspect_local_layout(local_dir)
+    citation = _read_citation(args.citation)
+    name = args.name or local_dir.name
+    meta = DatasetCardMeta(
+        name=name,
+        source_url=args.source_url,
+        citation=citation,
+        license=args.license,
+        license_name=args.license_name,
+        pretty_name=args.pretty_name,
+    )
+
+    card = make_dataset_card(meta, layout)
+    output.write_text(card)
+    logger.info(f"Wrote dataset card to {output}")
+    return 0
+
+
+def _run_stub(name: str) -> int:
+    print(f"`synthpix-hf {name}`: {_NOT_IMPLEMENTED}", file=sys.stderr)
+    return 2
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for ``synthpix-hf``.
+
+    Args:
+        argv: Optional explicit argument list; defaults to ``sys.argv[1:]``.
+
+    Returns:
+        int: A POSIX-style exit code.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "card":
+        return _run_card(args)
+    if args.command in {"push", "pull"}:
+        return _run_stub(args.command)
+
+    parser.error(f"Unknown command: {args.command}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/synthpix/hf/cli.py
+++ b/src/synthpix/hf/cli.py
@@ -21,9 +21,7 @@ _NOT_IMPLEMENTED = (
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="synthpix-hf",
-        description=(
-            "Tooling for synthpix-hosted Hugging Face PIV datasets."
-        ),
+        description=("Tooling for synthpix-hosted Hugging Face PIV datasets."),
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -32,7 +30,16 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     card.add_argument("local_dir", type=Path)
     card.add_argument("--source-url", required=True)
-    card.add_argument("--citation", required=True)
+    citation_group = card.add_mutually_exclusive_group(required=True)
+    citation_group.add_argument(
+        "--citation",
+        help="Literal citation text. Mutually exclusive with --citation-file.",
+    )
+    citation_group.add_argument(
+        "--citation-file",
+        type=Path,
+        help="Path to a file whose contents are used as the citation.",
+    )
     card.add_argument("--name", default=None)
     card.add_argument("--pretty-name", default=None)
     card.add_argument("--license", default="other")
@@ -51,12 +58,19 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _read_citation(value: str) -> str:
-    """Return the citation contents, reading from disk if ``value`` is a path."""
-    candidate = Path(value)
-    if candidate.is_file():
-        return candidate.read_text()
-    return value
+def _resolve_citation(args: argparse.Namespace) -> str:
+    """Return the citation contents from the chosen mutually exclusive flag.
+
+    Args:
+        args: Parsed ``argparse`` namespace from the ``card`` subparser.
+
+    Returns:
+        str: Either the literal ``--citation`` value or the contents of the
+            file pointed at by ``--citation-file``.
+    """
+    if args.citation_file is not None:
+        return args.citation_file.read_text()
+    return args.citation
 
 
 def _run_card(args: argparse.Namespace) -> int:
@@ -71,7 +85,7 @@ def _run_card(args: argparse.Namespace) -> int:
         return 1
 
     layout = inspect_local_layout(local_dir)
-    citation = _read_citation(args.citation)
+    citation = _resolve_citation(args)
     name = args.name or local_dir.name
     meta = DatasetCardMeta(
         name=name,
@@ -83,6 +97,7 @@ def _run_card(args: argparse.Namespace) -> int:
     )
 
     card = make_dataset_card(meta, layout)
+    output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(card)
     logger.info(f"Wrote dataset card to {output}")
     return 0
@@ -110,7 +125,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.command in {"push", "pull"}:
         return _run_stub(args.command)
 
+    # ``add_subparsers(required=True)`` makes this unreachable; ``parser.error``
+    # exits in any case but mypy/basedpyright need a concrete return.
     parser.error(f"Unknown command: {args.command}")
+    return 2
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/synthpix/hf/layout.py
+++ b/src/synthpix/hf/layout.py
@@ -1,0 +1,116 @@
+"""Local dataset layout introspection for the synthpix HF integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_SPLITS = ("train", "val", "test", "tune")
+
+
+@dataclass(frozen=True)
+class LayoutSummary:
+    """Summary of a local dataset directory layout.
+
+    Attributes:
+        splits: ``.mat`` file count per split that is present on disk.
+        reynolds_by_split: Sorted unique names of immediate subdirectories
+            grouped by split (typically Reynolds-number or scenario folders).
+        total_bytes: Sum of the size of every regular file under ``root``.
+        mat_files: Number of ``.mat`` files across all splits.
+        extra_files: Number of non-``.mat`` regular files (dotfiles excluded).
+    """
+
+    splits: dict[str, int] = field(default_factory=dict)
+    reynolds_by_split: dict[str, list[str]] = field(default_factory=dict)
+    total_bytes: int = 0
+    mat_files: int = 0
+    extra_files: int = 0
+
+
+def _is_hidden(path: Path) -> bool:
+    return path.name.startswith(".")
+
+
+def _scan_split(split_dir: Path) -> tuple[int, list[str], int, int, int]:
+    """Walk a split directory and gather counts.
+
+    Returns:
+        tuple: ``(mat_count, reynolds_subdirs, extra_count, total_bytes,
+            visited_files)``.
+    """
+    mat_count = 0
+    extra_count = 0
+    total_bytes = 0
+    subdir_names: set[str] = set()
+
+    for entry in split_dir.iterdir():
+        if _is_hidden(entry):
+            continue
+        if entry.is_dir():
+            subdir_names.add(entry.name)
+            for nested in entry.rglob("*"):
+                if _is_hidden(nested) or not nested.is_file():
+                    continue
+                total_bytes += nested.stat().st_size
+                if nested.suffix == ".mat":
+                    mat_count += 1
+                else:
+                    extra_count += 1
+        elif entry.is_file():
+            total_bytes += entry.stat().st_size
+            if entry.suffix == ".mat":
+                mat_count += 1
+            else:
+                extra_count += 1
+
+    reynolds = sorted(subdir_names)
+    return mat_count, reynolds, extra_count, total_bytes, 0
+
+
+def inspect_local_layout(root: Path) -> LayoutSummary:
+    """Inspect a local dataset directory and summarize its layout.
+
+    Args:
+        root: Path to the dataset root.
+
+    Returns:
+        LayoutSummary: A frozen snapshot of split counts, immediate
+            subdirectory names, byte totals, and ``.mat``/extra file counts.
+
+    Raises:
+        FileNotFoundError: If ``root`` does not exist.
+        NotADirectoryError: If ``root`` is not a directory.
+    """
+    root = Path(root)
+    if not root.exists():
+        raise FileNotFoundError(f"Dataset root not found: {root}")
+    if not root.is_dir():
+        raise NotADirectoryError(f"Dataset root is not a directory: {root}")
+
+    splits: dict[str, int] = {}
+    reynolds_by_split: dict[str, list[str]] = {}
+    total_bytes = 0
+    mat_files = 0
+    extra_files = 0
+
+    for split in _SPLITS:
+        split_dir = root / split
+        if not split_dir.is_dir():
+            continue
+        mat_count, reynolds, extra_count, split_bytes, _ = _scan_split(
+            split_dir
+        )
+        splits[split] = mat_count
+        reynolds_by_split[split] = reynolds
+        mat_files += mat_count
+        extra_files += extra_count
+        total_bytes += split_bytes
+
+    return LayoutSummary(
+        splits=splits,
+        reynolds_by_split=reynolds_by_split,
+        total_bytes=total_bytes,
+        mat_files=mat_files,
+        extra_files=extra_files,
+    )

--- a/src/synthpix/hf/layout.py
+++ b/src/synthpix/hf/layout.py
@@ -12,32 +12,58 @@ _SPLITS = ("train", "val", "test", "tune")
 class LayoutSummary:
     """Summary of a local dataset directory layout.
 
+    The dataclass is declared ``frozen=True``, which prevents attribute
+    reassignment, but the nested ``dict`` / ``list`` members are themselves
+    mutable in place. Callers that share a ``LayoutSummary`` instance across
+    threads or scopes must treat the inner containers as read-only.
+
     Attributes:
         splits: ``.mat`` file count per split that is present on disk.
-        reynolds_by_split: Sorted unique names of immediate subdirectories
-            grouped by split (typically Reynolds-number or scenario folders).
+        subdirs_by_split: Sorted unique names of immediate subdirectories
+            grouped by split (Reynolds-number folders for class-2, scenario
+            names like ``DNS_turbulence``/``cylinder`` for class-1).
         total_bytes: Sum of the size of every regular file under ``root``.
         mat_files: Number of ``.mat`` files across all splits.
-        extra_files: Number of non-``.mat`` regular files (dotfiles excluded).
+        extra_files: Number of non-``.mat`` regular files (excludes hidden).
     """
 
     splits: dict[str, int] = field(default_factory=dict)
-    reynolds_by_split: dict[str, list[str]] = field(default_factory=dict)
+    subdirs_by_split: dict[str, list[str]] = field(default_factory=dict)
     total_bytes: int = 0
     mat_files: int = 0
     extra_files: int = 0
 
 
-def _is_hidden(path: Path) -> bool:
-    return path.name.startswith(".")
+def _has_hidden_component(path: Path, root: Path) -> bool:
+    """Return whether ``path`` lies inside any hidden directory under ``root``.
 
-
-def _scan_split(split_dir: Path) -> tuple[int, list[str], int, int, int]:
-    """Walk a split directory and gather counts.
+    Args:
+        path: Candidate path to test.
+        root: Base path; only components below ``root`` are considered.
 
     Returns:
-        tuple: ``(mat_count, reynolds_subdirs, extra_count, total_bytes,
-            visited_files)``.
+        bool: ``True`` if any component of ``path`` (relative to ``root``)
+            starts with ``.``.
+    """
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        rel = path
+    return any(part.startswith(".") for part in rel.parts)
+
+
+def _scan_split(split_dir: Path) -> tuple[int, list[str], int, int]:
+    """Walk a split directory and gather counts.
+
+    Hidden entries are skipped at every depth: a file like
+    ``train/scene/.cache/x.mat`` is treated as hidden because one of its
+    ancestors starts with ``.``, not just files whose own name is dotted.
+
+    Args:
+        split_dir: Directory for a single split (``train``/``val``/...).
+
+    Returns:
+        tuple: ``(mat_count, subdir_names, extra_count, total_bytes)``.
     """
     mat_count = 0
     extra_count = 0
@@ -45,12 +71,14 @@ def _scan_split(split_dir: Path) -> tuple[int, list[str], int, int, int]:
     subdir_names: set[str] = set()
 
     for entry in split_dir.iterdir():
-        if _is_hidden(entry):
+        if entry.name.startswith("."):
             continue
         if entry.is_dir():
             subdir_names.add(entry.name)
             for nested in entry.rglob("*"):
-                if _is_hidden(nested) or not nested.is_file():
+                if not nested.is_file():
+                    continue
+                if _has_hidden_component(nested, split_dir):
                     continue
                 total_bytes += nested.stat().st_size
                 if nested.suffix == ".mat":
@@ -64,8 +92,7 @@ def _scan_split(split_dir: Path) -> tuple[int, list[str], int, int, int]:
             else:
                 extra_count += 1
 
-    reynolds = sorted(subdir_names)
-    return mat_count, reynolds, extra_count, total_bytes, 0
+    return mat_count, sorted(subdir_names), extra_count, total_bytes
 
 
 def inspect_local_layout(root: Path) -> LayoutSummary:
@@ -89,7 +116,7 @@ def inspect_local_layout(root: Path) -> LayoutSummary:
         raise NotADirectoryError(f"Dataset root is not a directory: {root}")
 
     splits: dict[str, int] = {}
-    reynolds_by_split: dict[str, list[str]] = {}
+    subdirs_by_split: dict[str, list[str]] = {}
     total_bytes = 0
     mat_files = 0
     extra_files = 0
@@ -98,18 +125,16 @@ def inspect_local_layout(root: Path) -> LayoutSummary:
         split_dir = root / split
         if not split_dir.is_dir():
             continue
-        mat_count, reynolds, extra_count, split_bytes, _ = _scan_split(
-            split_dir
-        )
+        mat_count, subdirs, extra_count, split_bytes = _scan_split(split_dir)
         splits[split] = mat_count
-        reynolds_by_split[split] = reynolds
+        subdirs_by_split[split] = subdirs
         mat_files += mat_count
         extra_files += extra_count
         total_bytes += split_bytes
 
     return LayoutSummary(
         splits=splits,
-        reynolds_by_split=reynolds_by_split,
+        subdirs_by_split=subdirs_by_split,
         total_bytes=total_bytes,
         mat_files=mat_files,
         extra_files=extra_files,

--- a/tests/hf/test_auth.py
+++ b/tests/hf/test_auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import types
 
 import pytest
 
@@ -58,15 +59,47 @@ def test_resolve_token_falls_back_to_cached(monkeypatch):
     pytest.importorskip("huggingface_hub")
     _clear_env(monkeypatch)
 
-    import huggingface_hub
+    import huggingface_hub  # noqa: PLC0415
 
     monkeypatch.setattr(
-        huggingface_hub.HfFolder, "get_token", lambda: "cached-token"
+        huggingface_hub, "get_token", lambda: "cached-token", raising=False
     )
 
     result = auth.resolve_token()
 
     assert result == "cached-token"
+
+
+def test_resolve_token_uses_modern_get_token_without_hffolder(monkeypatch):
+    """Regression: hub 1.x removed ``HfFolder``; ``get_token`` must be used.
+
+    Installs a fake ``huggingface_hub`` module that exposes ``get_token``
+    but NOT ``HfFolder`` (mirroring huggingface_hub >= 1.0). The old
+    ``_cached_token`` did ``from huggingface_hub import HfFolder`` which
+    raised inside the lazy ``__getattr__`` and was swallowed, so the
+    cached token was silently never found.
+    """
+    _clear_env(monkeypatch)
+
+    fake_hub = types.ModuleType("huggingface_hub")
+    fake_hub.get_token = lambda: "cli-cached-token"  # type: ignore[attr-defined]
+    assert not hasattr(fake_hub, "HfFolder")
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hub)
+
+    result = auth.resolve_token()
+
+    assert result == "cli-cached-token"
+
+
+def test_resolve_token_cached_empty_string_is_ignored(monkeypatch):
+    """An empty cached token must be treated as missing (-> ``None``)."""
+    _clear_env(monkeypatch)
+
+    fake_hub = types.ModuleType("huggingface_hub")
+    fake_hub.get_token = lambda: ""  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hub)
+
+    assert auth.resolve_token() is None
 
 
 def test_resolve_token_returns_none_when_nothing_set(monkeypatch):

--- a/tests/hf/test_auth.py
+++ b/tests/hf/test_auth.py
@@ -1,0 +1,91 @@
+"""Tests for ``synthpix.hf.auth`` token resolution."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from synthpix.hf import auth
+
+
+def _clear_env(monkeypatch):
+    """Remove every HF-related env var to start each test from a blank slate."""
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HF_HUB_TOKEN", raising=False)
+
+
+def test_resolve_token_prefers_explicit_argument(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HF_TOKEN", "env-token")
+    monkeypatch.setenv("HF_HUB_TOKEN", "hub-token")
+
+    result = auth.resolve_token("explicit-token")
+
+    assert result == "explicit-token"
+
+
+def test_resolve_token_uses_hf_token_when_no_explicit(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HF_TOKEN", "env-token")
+    monkeypatch.setenv("HF_HUB_TOKEN", "hub-token")
+
+    result = auth.resolve_token()
+
+    assert result == "env-token"
+
+
+def test_resolve_token_uses_hf_hub_token_when_hf_token_missing(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HF_HUB_TOKEN", "hub-token")
+
+    result = auth.resolve_token()
+
+    assert result == "hub-token"
+
+
+def test_resolve_token_ignores_empty_strings(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HF_TOKEN", "")
+    monkeypatch.setenv("HF_HUB_TOKEN", "hub-token")
+
+    result = auth.resolve_token(explicit="")
+
+    assert result == "hub-token"
+
+
+def test_resolve_token_falls_back_to_cached(monkeypatch):
+    pytest.importorskip("huggingface_hub")
+    _clear_env(monkeypatch)
+
+    import huggingface_hub
+
+    monkeypatch.setattr(
+        huggingface_hub.HfFolder, "get_token", lambda: "cached-token"
+    )
+
+    result = auth.resolve_token()
+
+    assert result == "cached-token"
+
+
+def test_resolve_token_returns_none_when_nothing_set(monkeypatch):
+    _clear_env(monkeypatch)
+
+    # Force the lazy import to fail so we exercise the safe branch when
+    # ``huggingface_hub`` is missing and no env/argument is provided.
+    monkeypatch.setitem(sys.modules, "huggingface_hub", None)
+
+    result = auth.resolve_token()
+
+    assert result is None
+
+
+def test_resolve_token_does_not_raise_when_hub_missing(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setitem(sys.modules, "huggingface_hub", None)
+
+    # Should not raise even though we have nothing to fall back to.
+    result = auth.resolve_token()
+
+    assert result is None

--- a/tests/hf/test_card.py
+++ b/tests/hf/test_card.py
@@ -15,7 +15,7 @@ from synthpix.hf.layout import LayoutSummary
 def _fake_layout() -> LayoutSummary:
     return LayoutSummary(
         splits={"train": 10, "val": 2, "test": 4},
-        reynolds_by_split={
+        subdirs_by_split={
             "train": [],
             "val": [],
             "test": ["DNS_turbulence", "cylinder"],
@@ -148,10 +148,49 @@ def test_card_meta_handles_commit_failure(monkeypatch):
     assert "Example PIV" in card
 
 
+def test_frontmatter_safely_encodes_special_characters():
+    # ``pretty_name`` with quotes/backslashes must produce parseable YAML.
+    meta = DatasetCardMeta(
+        name="example-piv",
+        source_url="https://example.org/data",
+        citation="cite",
+        pretty_name='dangerous: "value"\nwith \\ break',
+        tags=('with "quote"', "with\\backslash"),
+        synthpix_version="0.1.2",
+        synthpix_commit="abc1234",
+    )
+
+    card = make_dataset_card(meta, _fake_layout())
+    fm = _parse_frontmatter(card)
+
+    assert fm["pretty_name"] == 'dangerous: "value"\nwith \\ break'
+    assert 'with "quote"' in fm["tags"]
+    assert "with\\backslash" in fm["tags"]
+
+
+def test_citation_with_triple_backticks_uses_longer_fence():
+    # Citations that embed ``` must not close the surrounding fence.
+    embedded = "before\n```\ncode block inside citation\n```\nafter"
+    meta = DatasetCardMeta(
+        name="example-piv",
+        source_url="https://example.org/data",
+        citation=embedded,
+        pretty_name="Example PIV",
+        synthpix_version="0.1.2",
+        synthpix_commit="abc",
+    )
+
+    card = make_dataset_card(meta, _fake_layout())
+
+    # Whole citation appears verbatim and is bracketed by a >=4-tick fence.
+    assert embedded in card
+    assert "````" in card
+
+
 def test_card_handles_empty_reynolds_map():
     layout = LayoutSummary(
         splits={"train": 1},
-        reynolds_by_split={"train": []},
+        subdirs_by_split={"train": []},
         total_bytes=64,
         mat_files=1,
         extra_files=0,

--- a/tests/hf/test_card.py
+++ b/tests/hf/test_card.py
@@ -1,0 +1,170 @@
+"""Tests for ``synthpix.hf.card`` README generation."""
+
+from __future__ import annotations
+
+import io
+import subprocess
+
+import pytest
+from ruamel.yaml import YAML
+
+from synthpix.hf.card import DatasetCardMeta, make_dataset_card
+from synthpix.hf.layout import LayoutSummary
+
+
+def _fake_layout() -> LayoutSummary:
+    return LayoutSummary(
+        splits={"train": 10, "val": 2, "test": 4},
+        reynolds_by_split={
+            "train": [],
+            "val": [],
+            "test": ["DNS_turbulence", "cylinder"],
+        },
+        total_bytes=1024,
+        mat_files=16,
+        extra_files=0,
+    )
+
+
+def _parse_frontmatter(card: str) -> dict:
+    assert card.startswith("---\n")
+    end = card.index("\n---\n", 4)
+    body = card[4:end]
+    yaml = YAML(typ="safe")
+    return yaml.load(io.StringIO(body))
+
+
+def test_card_starts_with_yaml_frontmatter():
+    meta = DatasetCardMeta(
+        name="example-piv",
+        source_url="https://example.org/data",
+        citation="cite me",
+        pretty_name="Example PIV",
+        synthpix_version="9.9.9",
+        synthpix_commit="abc1234",
+    )
+
+    card = make_dataset_card(meta, _fake_layout())
+    fm = _parse_frontmatter(card)
+
+    assert fm["license"] == "other"
+    assert fm["license_name"] == "research-only-arr"
+    assert fm["pretty_name"] == "Example PIV"
+    assert "PIV" in fm["tags"]
+    assert "synthetic" in fm["tags"]
+
+
+def test_card_body_contains_source_citation_and_counts():
+    meta = DatasetCardMeta(
+        name="example-piv",
+        source_url="https://example.org/data",
+        citation="@article{foo}",
+        pretty_name="Example PIV",
+        synthpix_version="0.1.2",
+        synthpix_commit="abc1234",
+    )
+
+    card = make_dataset_card(meta, _fake_layout())
+
+    assert "Example PIV" in card
+    assert "https://example.org/data" in card
+    assert "@article{foo}" in card
+    assert "train" in card
+    assert "10" in card
+    assert "DNS_turbulence" in card
+    assert "0.1.2" in card
+    assert "abc1234" in card
+
+
+def test_card_license_note_is_present():
+    meta = DatasetCardMeta(
+        name="example-piv",
+        source_url="https://example.org/data",
+        citation="cite",
+        pretty_name="Example PIV",
+        synthpix_version="0.1.2",
+        synthpix_commit=None,
+    )
+
+    card = make_dataset_card(meta, _fake_layout())
+
+    assert "hosted under terms set by the original authors" in card
+
+
+def test_card_meta_auto_fills_synthpix_version(monkeypatch):
+    monkeypatch.setattr(
+        "synthpix.hf.card._lookup_synthpix_version", lambda: "1.2.3"
+    )
+
+    meta = DatasetCardMeta(
+        name="example-piv",
+        source_url="https://example.org/data",
+        citation="cite",
+        pretty_name="Example PIV",
+        synthpix_commit="deadbee",
+    )
+
+    card = make_dataset_card(meta, _fake_layout())
+
+    assert "1.2.3" in card
+
+
+def test_card_meta_auto_fills_synthpix_commit(monkeypatch):
+    def fake_check_output(*args, **kwargs):
+        return b"feedface1234\n"
+
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+
+    meta = DatasetCardMeta(
+        name="example-piv",
+        source_url="https://example.org/data",
+        citation="cite",
+        pretty_name="Example PIV",
+        synthpix_version="0.1.2",
+    )
+
+    card = make_dataset_card(meta, _fake_layout())
+
+    assert "feedface1234" in card
+
+
+def test_card_meta_handles_commit_failure(monkeypatch):
+    def raise_error(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, ["git"])
+
+    monkeypatch.setattr(subprocess, "check_output", raise_error)
+
+    meta = DatasetCardMeta(
+        name="example-piv",
+        source_url="https://example.org/data",
+        citation="cite",
+        pretty_name="Example PIV",
+        synthpix_version="0.1.2",
+    )
+
+    # Should not raise.
+    card = make_dataset_card(meta, _fake_layout())
+
+    assert "Example PIV" in card
+
+
+def test_card_handles_empty_reynolds_map():
+    layout = LayoutSummary(
+        splits={"train": 1},
+        reynolds_by_split={"train": []},
+        total_bytes=64,
+        mat_files=1,
+        extra_files=0,
+    )
+    meta = DatasetCardMeta(
+        name="example-piv",
+        source_url="https://example.org/data",
+        citation="cite",
+        pretty_name="Example PIV",
+        synthpix_version="0.1.2",
+        synthpix_commit="abc",
+    )
+
+    card = make_dataset_card(meta, layout)
+
+    assert "train" in card

--- a/tests/hf/test_cli.py
+++ b/tests/hf/test_cli.py
@@ -1,0 +1,132 @@
+"""Tests for the ``synthpix-hf`` argparse CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from synthpix.hf import cli
+
+
+def _populate(tmp_path: Path) -> None:
+    """Drop a single ``.mat`` file so ``inspect_local_layout`` succeeds."""
+    train = tmp_path / "train"
+    train.mkdir()
+    (train / "flow.mat").write_bytes(b"x" * 8)
+
+
+def test_card_subcommand_writes_readme(tmp_path: Path):
+    _populate(tmp_path)
+    rc = cli.main(
+        [
+            "card",
+            str(tmp_path),
+            "--source-url",
+            "https://example.org/data",
+            "--citation",
+            "fake citation",
+            "--pretty-name",
+            "Example",
+        ]
+    )
+
+    readme = tmp_path / "README.md"
+    assert rc == 0
+    assert readme.exists()
+    assert "fake citation" in readme.read_text()
+
+
+def test_card_subcommand_refuses_overwrite_without_force(tmp_path: Path):
+    _populate(tmp_path)
+    readme = tmp_path / "README.md"
+    readme.write_text("existing content")
+
+    rc = cli.main(
+        [
+            "card",
+            str(tmp_path),
+            "--source-url",
+            "https://example.org/data",
+            "--citation",
+            "fake citation",
+        ]
+    )
+
+    assert rc != 0
+    assert readme.read_text() == "existing content"
+
+
+def test_card_subcommand_overwrites_with_force(tmp_path: Path):
+    _populate(tmp_path)
+    readme = tmp_path / "README.md"
+    readme.write_text("existing content")
+
+    rc = cli.main(
+        [
+            "card",
+            str(tmp_path),
+            "--source-url",
+            "https://example.org/data",
+            "--citation",
+            "fake citation",
+            "--force",
+        ]
+    )
+
+    assert rc == 0
+    assert "fake citation" in readme.read_text()
+
+
+def test_card_subcommand_reads_citation_from_file(tmp_path: Path):
+    _populate(tmp_path)
+    citation_file = tmp_path / "CITATION.bib"
+    citation_file.write_text("@misc{example, title={Example}}")
+
+    rc = cli.main(
+        [
+            "card",
+            str(tmp_path),
+            "--source-url",
+            "https://example.org/data",
+            "--citation",
+            str(citation_file),
+        ]
+    )
+
+    readme = tmp_path / "README.md"
+    assert rc == 0
+    assert "@misc{example" in readme.read_text()
+
+
+def test_card_subcommand_respects_output(tmp_path: Path):
+    _populate(tmp_path)
+    output = tmp_path / "custom.md"
+
+    rc = cli.main(
+        [
+            "card",
+            str(tmp_path),
+            "--source-url",
+            "https://example.org/data",
+            "--citation",
+            "fake citation",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert rc == 0
+    assert output.exists()
+    assert not (tmp_path / "README.md").exists()
+
+
+@pytest.mark.parametrize("subcommand", ["push", "pull"])
+def test_stub_subcommands_report_not_implemented(
+    subcommand: str, capsys
+):
+    rc = cli.main([subcommand])
+
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert "not yet implemented" in (captured.out + captured.err).lower()

--- a/tests/hf/test_cli.py
+++ b/tests/hf/test_cli.py
@@ -89,7 +89,7 @@ def test_card_subcommand_reads_citation_from_file(tmp_path: Path):
             str(tmp_path),
             "--source-url",
             "https://example.org/data",
-            "--citation",
+            "--citation-file",
             str(citation_file),
         ]
     )
@@ -97,6 +97,73 @@ def test_card_subcommand_reads_citation_from_file(tmp_path: Path):
     readme = tmp_path / "README.md"
     assert rc == 0
     assert "@misc{example" in readme.read_text()
+
+
+def test_card_citation_literal_not_treated_as_path(tmp_path: Path):
+    # A literal --citation that matches a CWD file must not be silently read.
+    _populate(tmp_path)
+    # Create a file whose name matches the literal we will pass.
+    decoy = tmp_path / "lookup-by-coincidence.txt"
+    decoy.write_text("file-contents-should-not-leak")
+
+    rc = cli.main(
+        [
+            "card",
+            str(tmp_path),
+            "--source-url",
+            "https://example.org/data",
+            "--citation",
+            str(decoy),
+        ]
+    )
+
+    readme = (tmp_path / "README.md").read_text()
+    assert rc == 0
+    # The literal string was preserved verbatim — the decoy content did not leak in.
+    assert "file-contents-should-not-leak" not in readme
+    assert str(decoy) in readme
+
+
+def test_card_citation_and_citation_file_are_mutually_exclusive(tmp_path: Path):
+    _populate(tmp_path)
+    citation_file = tmp_path / "CITATION.bib"
+    citation_file.write_text("@misc{example}")
+
+    with pytest.raises(SystemExit):
+        cli.main(
+            [
+                "card",
+                str(tmp_path),
+                "--source-url",
+                "https://example.org/data",
+                "--citation",
+                "literal",
+                "--citation-file",
+                str(citation_file),
+            ]
+        )
+
+
+def test_card_output_creates_missing_parent_directory(tmp_path: Path):
+    _populate(tmp_path)
+    output = tmp_path / "nested" / "deeper" / "card.md"
+    assert not output.parent.exists()
+
+    rc = cli.main(
+        [
+            "card",
+            str(tmp_path),
+            "--source-url",
+            "https://example.org/data",
+            "--citation",
+            "fake citation",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert rc == 0
+    assert output.exists()
 
 
 def test_card_subcommand_respects_output(tmp_path: Path):

--- a/tests/hf/test_layout.py
+++ b/tests/hf/test_layout.py
@@ -1,0 +1,88 @@
+"""Tests for ``synthpix.hf.layout`` directory introspection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from synthpix.hf.layout import LayoutSummary, inspect_local_layout
+
+
+def _make_mat(path: Path, payload: bytes = b"x" * 16) -> None:
+    """Create a fake ``.mat`` file with a known byte payload."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+
+
+@pytest.fixture
+def synthetic_tree(tmp_path: Path) -> Path:
+    """Build a representative dataset layout under ``tmp_path``."""
+    for i in range(4):
+        _make_mat(tmp_path / "train" / f"flow_{i:04d}.mat")
+    for i in range(2):
+        _make_mat(tmp_path / "val" / f"flow_{i:04d}.mat")
+    for i in range(2):
+        _make_mat(
+            tmp_path / "test" / "DNS_turbulence" / "Re100" / f"flow_{i}.mat"
+        )
+    for i in range(2):
+        _make_mat(tmp_path / "test" / "cylinder" / f"flow_{i}.mat")
+
+    # Empty tune split — should still be reported with count 0.
+    (tmp_path / "tune").mkdir()
+
+    # Extra non-``.mat`` file should be counted under ``extra_files``.
+    (tmp_path / "train" / "notes.txt").write_text("ignore me")
+
+    # Dotfiles must be skipped entirely.
+    (tmp_path / "train" / ".hidden").write_text("nope")
+
+    return tmp_path
+
+
+def test_inspect_returns_layout_summary(synthetic_tree: Path):
+    summary = inspect_local_layout(synthetic_tree)
+
+    assert isinstance(summary, LayoutSummary)
+
+
+def test_inspect_counts_mat_files_per_split(synthetic_tree: Path):
+    summary = inspect_local_layout(synthetic_tree)
+
+    assert summary.splits["train"] == 4
+    assert summary.splits["val"] == 2
+    assert summary.splits["test"] == 4
+    assert summary.splits["tune"] == 0
+
+
+def test_inspect_maps_reynolds_subdirs(synthetic_tree: Path):
+    summary = inspect_local_layout(synthetic_tree)
+
+    assert summary.reynolds_by_split["test"] == ["DNS_turbulence", "cylinder"]
+    # Splits without ``Re*``-style subdirs get an empty list.
+    assert summary.reynolds_by_split["train"] == []
+
+
+def test_inspect_counts_extras_and_skips_dotfiles(synthetic_tree: Path):
+    summary = inspect_local_layout(synthetic_tree)
+
+    assert summary.mat_files == 4 + 2 + 4
+    assert summary.extra_files == 1
+    assert summary.total_bytes > 0
+
+
+def test_inspect_tolerates_missing_split(tmp_path: Path):
+    _make_mat(tmp_path / "train" / "flow.mat")
+
+    summary = inspect_local_layout(tmp_path)
+
+    assert "tune" not in summary.splits
+    assert summary.splits == {"train": 1}
+
+
+def test_layout_summary_is_frozen(synthetic_tree: Path):
+    summary = inspect_local_layout(synthetic_tree)
+
+    with pytest.raises(Exception):
+        summary.mat_files = 0  # type: ignore[misc]

--- a/tests/hf/test_layout.py
+++ b/tests/hf/test_layout.py
@@ -59,9 +59,9 @@ def test_inspect_counts_mat_files_per_split(synthetic_tree: Path):
 def test_inspect_maps_reynolds_subdirs(synthetic_tree: Path):
     summary = inspect_local_layout(synthetic_tree)
 
-    assert summary.reynolds_by_split["test"] == ["DNS_turbulence", "cylinder"]
+    assert summary.subdirs_by_split["test"] == ["DNS_turbulence", "cylinder"]
     # Splits without ``Re*``-style subdirs get an empty list.
-    assert summary.reynolds_by_split["train"] == []
+    assert summary.subdirs_by_split["train"] == []
 
 
 def test_inspect_counts_extras_and_skips_dotfiles(synthetic_tree: Path):
@@ -79,6 +79,22 @@ def test_inspect_tolerates_missing_split(tmp_path: Path):
 
     assert "tune" not in summary.splits
     assert summary.splits == {"train": 1}
+
+
+def test_inspect_skips_files_in_hidden_directories(tmp_path: Path):
+    # Files nested under any hidden ancestor must not be counted.
+    _make_mat(tmp_path / "train" / "real.mat")
+    _make_mat(tmp_path / "train" / ".cache" / "leaked.mat")
+    _make_mat(tmp_path / "train" / "scene" / ".tmp" / "still_leaked.mat")
+    (tmp_path / "train" / "scene" / ".tmp" / "junk.txt").write_text("nope")
+
+    summary = inspect_local_layout(tmp_path)
+
+    assert summary.splits["train"] == 1
+    assert summary.mat_files == 1
+    assert summary.extra_files == 0
+    # ``.cache`` (hidden dir) must not surface as a subdir name.
+    assert ".cache" not in summary.subdirs_by_split["train"]
 
 
 def test_layout_summary_is_frozen(synthetic_tree: Path):

--- a/uv.lock
+++ b/uv.lock
@@ -2951,7 +2951,7 @@ requires-dist = [
     { name = "h5py", specifier = ">=3.13.0" },
     { name = "hf-transfer", marker = "extra == 'hf'", specifier = ">=0.1.6" },
     { name = "hf-xet", marker = "extra == 'hf'", specifier = ">=0.1.0" },
-    { name = "huggingface-hub", marker = "extra == 'hf'", specifier = ">=0.27" },
+    { name = "huggingface-hub", marker = "extra == 'hf'", specifier = ">=1.0" },
     { name = "jax", specifier = ">=0.6.0" },
     { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda12'", specifier = ">=0.6.0" },
     { name = "matplotlib", marker = "extra == 'dev'", specifier = ">=3.10.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -953,6 +953,38 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-transfer"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/eb/8fc64f40388c29ce8ce3b2b180a089d4d6b25b1d0d232d016704cb852104/hf_transfer-0.1.9.tar.gz", hash = "sha256:035572865dab29d17e783fbf1e84cf1cb24f3fcf8f1b17db1cfc7fdf139f02bf", size = 25201, upload-time = "2025-01-07T10:05:12.947Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/78/0dce00208f585fae675f40033ef9a30dedfa83665d5ac79f16beb4a0a6c2/hf_transfer-0.1.9-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:6e94e8822da79573c9b6ae4d6b2f847c59a7a06c5327d7db20751b68538dc4f6", size = 1386084, upload-time = "2025-01-07T10:04:47.874Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2e/3d60b1a9e9f29a2152aa66c823bf5e399ae7be3fef310ff0de86779c5d2d/hf_transfer-0.1.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ebc4ab9023414880c8b1d3c38174d1c9989eb5022d37e814fa91a3060123eb0", size = 1343558, upload-time = "2025-01-07T10:04:42.313Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/38/130a5ac3747f104033591bcac1c961cb1faadfdc91704f59b09c0b465ff2/hf_transfer-0.1.9-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8674026f21ed369aa2a0a4b46000aca850fc44cd2b54af33a172ce5325b4fc82", size = 3726676, upload-time = "2025-01-07T10:04:11.539Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a1/f4e27c5ad17aac616ae0849e2aede5aae31db8267a948c6b3eeb9fd96446/hf_transfer-0.1.9-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a736dfbb2c84f5a2c975478ad200c0c8bfcb58a25a35db402678fb87ce17fa4", size = 3062920, upload-time = "2025-01-07T10:04:16.297Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0d/727abdfba39bc3f1132cfa4c970588c2c0bb0d82fe2d645cc10f4e2f8e0b/hf_transfer-0.1.9-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:504b8427fd785dd8546d53b9fafe6e436bd7a3adf76b9dce556507650a7b4567", size = 3578681, upload-time = "2025-01-07T10:04:29.702Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d0/2b213eb1ea8b1252ccaf1a6c804d0aba03fea38aae4124df6a3acb70511a/hf_transfer-0.1.9-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2c7fc1b85f4d0f76e452765d7648c9f4bfd0aedb9ced2ae1ebfece2d8cfaf8e2", size = 3398837, upload-time = "2025-01-07T10:04:22.778Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/8a/79dbce9006e0bd6b74516f97451a7b7c64dbbb426df15d901dd438cfeee3/hf_transfer-0.1.9-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d991376f0eac70a60f0cbc95602aa708a6f7c8617f28b4945c1431d67b8e3c8", size = 3546986, upload-time = "2025-01-07T10:04:36.415Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f7/9ac239b6ee6fe0bad130325d987a93ea58c4118e50479f0786f1733b37e8/hf_transfer-0.1.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e6ac4eddcd99575ed3735ed911ddf9d1697e2bd13aa3f0ad7e3904dd4863842e", size = 4071715, upload-time = "2025-01-07T10:04:53.224Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a3/0ed697279f5eeb7a40f279bd783cf50e6d0b91f24120dcf66ef2cf8822b4/hf_transfer-0.1.9-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:57fd9880da1ee0f47250f735f791fab788f0aa1ee36afc49f761349869c8b4d9", size = 3388081, upload-time = "2025-01-07T10:04:57.818Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/eb/47e477bdf1d784f31c7540db6cc8c354b777e51a186897a7abda34517f36/hf_transfer-0.1.9-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:5d561f0520f493c66b016d99ceabe69c23289aa90be38dd802d2aef279f15751", size = 3658654, upload-time = "2025-01-07T10:05:03.168Z" },
+    { url = "https://files.pythonhosted.org/packages/45/07/6661e43fbee09594a8a5e9bb778107d95fe38dac4c653982afe03d32bd4d/hf_transfer-0.1.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a5b366d34cd449fe9b20ef25941e6eef0460a2f74e7389f02e673e1f88ebd538", size = 3690551, upload-time = "2025-01-07T10:05:09.238Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f5/461d2e5f307e5048289b1168d5c642ae3bb2504e88dff1a38b92ed990a21/hf_transfer-0.1.9-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e66acf91df4a8b72f60223059df3003062a5ae111757187ed1a06750a30e911b", size = 1393046, upload-time = "2025-01-07T10:04:51.003Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ba/8d9fd9f1083525edfcb389c93738c802f3559cb749324090d7109c8bf4c2/hf_transfer-0.1.9-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:8669dbcc7a3e2e8d61d42cd24da9c50d57770bd74b445c65123291ca842a7e7a", size = 1348126, upload-time = "2025-01-07T10:04:45.712Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/cd7885bc9959421065a6fae0fe67b6c55becdeda4e69b873e52976f9a9f0/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8fd0167c4407a3bc4cdd0307e65ada2294ec04f1813d8a69a5243e379b22e9d8", size = 3728604, upload-time = "2025-01-07T10:04:14.173Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/2e/a072cf196edfeda3310c9a5ade0a0fdd785e6154b3ce24fc738c818da2a7/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ee8b10afedcb75f71091bcc197c526a6ebf5c58bbbadb34fdeee6160f55f619f", size = 3064995, upload-time = "2025-01-07T10:04:18.663Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/84/aec9ef4c0fab93c1ea2b1badff38c78b4b2f86f0555b26d2051dbc920cde/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5828057e313de59300dd1abb489444bc452efe3f479d3c55b31a8f680936ba42", size = 3580908, upload-time = "2025-01-07T10:04:32.834Z" },
+    { url = "https://files.pythonhosted.org/packages/29/63/b560d39651a56603d64f1a0212d0472a44cbd965db2fa62b99d99cb981bf/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc6bd19e1cc177c66bdef15ef8636ad3bde79d5a4f608c158021153b4573509d", size = 3400839, upload-time = "2025-01-07T10:04:26.122Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d8/f87ea6f42456254b48915970ed98e993110521e9263472840174d32c880d/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdca9bfb89e6f8f281890cc61a8aff2d3cecaff7e1a4d275574d96ca70098557", size = 3552664, upload-time = "2025-01-07T10:04:40.123Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/56/1267c39b65fc8f4e2113b36297320f102718bf5799b544a6cbe22013aa1d/hf_transfer-0.1.9-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:89a23f58b7b7effbc047b8ca286f131b17728c99a9f972723323003ffd1bb916", size = 4073732, upload-time = "2025-01-07T10:04:55.624Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1a/9c748befbe3decf7cb415e34f8a0c3789a0a9c55910dea73d581e48c0ce5/hf_transfer-0.1.9-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:dc7fff1345980d6c0ebb92c811d24afa4b98b3e07ed070c8e38cc91fd80478c5", size = 3390096, upload-time = "2025-01-07T10:04:59.98Z" },
+    { url = "https://files.pythonhosted.org/packages/72/85/4c03da147b6b4b7cb12e074d3d44eee28604a387ed0eaf7eaaead5069c57/hf_transfer-0.1.9-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:1a6bd16c667ebe89a069ca163060127a794fa3a3525292c900b8c8cc47985b0d", size = 3664743, upload-time = "2025-01-07T10:05:05.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/6e/e597b04f753f1b09e6893075d53a82a30c13855cbaa791402695b01e369f/hf_transfer-0.1.9-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d2fde99d502093ade3ab1b53f80da18480e9902aa960dab7f74fb1b9e5bc5746", size = 3695243, upload-time = "2025-01-07T10:05:11.411Z" },
+    { url = "https://files.pythonhosted.org/packages/09/89/d4e234727a26b2546c8fb70a276cd924260d60135f2165bf8b9ed67bb9a4/hf_transfer-0.1.9-cp38-abi3-win32.whl", hash = "sha256:435cc3cdc8524ce57b074032b8fd76eed70a4224d2091232fa6a8cef8fd6803e", size = 1086605, upload-time = "2025-01-07T10:05:18.873Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/14/f1e15b851d1c2af5b0b1a82bf8eb10bda2da62d98180220ba6fd8879bb5b/hf_transfer-0.1.9-cp38-abi3-win_amd64.whl", hash = "sha256:16f208fc678911c37e11aa7b586bc66a37d02e636208f18b6bc53d29b5df40ad", size = 1160240, upload-time = "2025-01-07T10:05:14.324Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2905,6 +2937,8 @@ download = [
     { name = "tensorflow-cpu" },
 ]
 hf = [
+    { name = "hf-transfer" },
+    { name = "hf-xet" },
     { name = "huggingface-hub" },
 ]
 
@@ -2915,7 +2949,9 @@ requires-dist = [
     { name = "gdown", marker = "extra == 'download'", specifier = ">=5.1.0" },
     { name = "grain", specifier = ">=0.2.13" },
     { name = "h5py", specifier = ">=3.13.0" },
-    { name = "huggingface-hub", extras = ["cli", "hf-transfer"], marker = "extra == 'hf'", specifier = ">=0.27" },
+    { name = "hf-transfer", marker = "extra == 'hf'", specifier = ">=0.1.6" },
+    { name = "hf-xet", marker = "extra == 'hf'", specifier = ">=0.1.0" },
+    { name = "huggingface-hub", marker = "extra == 'hf'", specifier = ">=0.27" },
     { name = "jax", specifier = ">=0.6.0" },
     { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda12'", specifier = ">=0.6.0" },
     { name = "matplotlib", marker = "extra == 'dev'", specifier = ">=3.10.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,29 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "array-record"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -871,6 +894,15 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
 name = "h5py"
 version = "3.15.1"
 source = { registry = "https://pypi.org/simple" }
@@ -918,6 +950,86 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/39/a7ef948ddf4d1c556b0b2b9559534777bccc318543b3f5a1efdf6b556c9c/h5py-3.15.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99d374a21f7321a4c6ab327c4ab23bd925ad69821aeb53a1e75dd809d19f67fa", size = 5025426, upload-time = "2025-10-16T10:35:19.831Z" },
     { url = "https://files.pythonhosted.org/packages/b6/d8/7368679b8df6925b8415f9dcc9ab1dab01ddc384d2b2c24aac9191bd9ceb/h5py-3.15.1-cp314-cp314-win_amd64.whl", hash = "sha256:9c73d1d7cdb97d5b17ae385153472ce118bed607e43be11e9a9deefaa54e0734", size = 2865704, upload-time = "2025-10-16T10:35:22.658Z" },
     { url = "https://files.pythonhosted.org/packages/d3/b7/4a806f85d62c20157e62e58e03b27513dc9c55499768530acc4f4c5ce4be/h5py-3.15.1-cp314-cp314-win_arm64.whl", hash = "sha256:a6d8c5a05a76aca9a494b4c53ce8a9c29023b7f64f625c6ce1841e92a362ccdf", size = 2465544, upload-time = "2025-10-16T10:35:25.695Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/d8/5c06fc76461418326a7decf8367480c35be11a41fd938633929c60a9ec6b/hf_xet-1.5.0.tar.gz", hash = "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948", size = 837196, upload-time = "2026-05-06T06:18:15.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/9b/6912c99070915a4f28119e3c5b52a9abd1eec0ad5cb293b8c967a0c6f5a2/hf_xet-1.5.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7d70fe2ce97b9db73b9c9b9c81fe3693640aec83416a966c446afea54acfae3c", size = 4023383, upload-time = "2026-05-06T06:17:53.947Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6d/9563cfde59b5d8128a9c7ec972a087f4c782e4f7bac5a85234edfd5d5e49/hf_xet-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:73a0dae8c71de3b0633a45c73f4a4a5ed09e94b43441d82981a781d4f12baa42", size = 3792751, upload-time = "2026-05-06T06:17:51.791Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a5/ed5a0cf35b49a0571af5a8f53416dad1877a718c021c9937c3a53cb45781/hf_xet-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a60290ec57e9b71767fba7c3645ddafdd0759974b540441510c629c6db6db24a", size = 4456058, upload-time = "2026-05-06T06:17:40.735Z" },
+    { url = "https://files.pythonhosted.org/packages/60/fb/3ae8bf2a7a37a4197d0195d7247fd25b3952e15cb8a599e285dfaa6f52b3/hf_xet-1.5.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e5de0f6deada0dada870bb376a11bcd1f08abf3a968a6d118f33e72d1b1eb480", size = 4250783, upload-time = "2026-05-06T06:17:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/8bae40d4d91525085137196e84eb0ed49cf65b5e96e5c3ecdadd8bd0fac2/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c799d49f1a5544a0ef7591c0ee75e0d6b93d6f56dc7a4979f59f7518d2872216", size = 4445594, upload-time = "2026-05-06T06:18:04.219Z" },
+    { url = "https://files.pythonhosted.org/packages/13/59/c74efbbd4e8728172b2cc72a2bc014d2947a4b7bdced932fbd3f5da1a4e5/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2baea1b0b989e5c152fe81425f7745ddc8901280ba3d97c98d8cdece7b706c60", size = 4663995, upload-time = "2026-05-06T06:18:06.1Z" },
+    { url = "https://files.pythonhosted.org/packages/73/32/8e1e0410af64cda9b139d1dcebdc993a8ff9c8c7c0e2696ae356d75ccc0d/hf_xet-1.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:526345b3ed45f374f6317349df489167606736c876241ba984105afe7fd4839d", size = 3966608, upload-time = "2026-05-06T06:18:19.74Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/34/a8febc8f4edbea8b3e21b02ebc8b628679b84ba7e45cde624a7736b51500/hf_xet-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:786d28e2eb8315d5035544b9d137b4a842d600c434bb91bf7d0d953cce906ad4", size = 3796946, upload-time = "2026-05-06T06:18:17.568Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/20/8fc8996afe5815fa1a6be8e9e5c02f24500f409d599e905800d498a4e14d/hf_xet-1.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:872d5601e6deea30d15865ede55d29eac6daf5a534ab417b99b6ef6b076dd96c", size = 4023495, upload-time = "2026-05-06T06:18:01.94Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/93d84463c00cecb561a7508aa6303e35ee2894294eac14245526924415fe/hf_xet-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9929561f5abf4581c8ea79587881dfef6b8abb2a0d8a51915936fc2a614f4e73", size = 3792731, upload-time = "2026-05-06T06:18:00.021Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/5a/8ec8e0c863b382d00b3c2e2af6ded6b06371be617144a625903a6d562f4b/hf_xet-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f7b7bbae318e583a86fb21e5a4a175d6721d628a2874f4bd022d0e660c32a682", size = 4456738, upload-time = "2026-05-06T06:17:49.574Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/ca/f7effa1a67717da2bcc6b6c28f71c6ca648c77acaec4e2c32f40cbe16d85/hf_xet-1.5.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:cf7b2dc6f31a4ea754bb50f74cde482dcf5d366d184076d8530b9872787f3761", size = 4251622, upload-time = "2026-05-06T06:17:47.096Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f2/19247dba3e231cf77dec59ddfb878f00057635ff773d099c9b59d37812c3/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8dbcbab554c9ef158ef2c991545c3e970ddd8cc7acdcd0a78c5a41095dab4ded", size = 4445667, upload-time = "2026-05-06T06:18:11.983Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/64/6f116801a3bcfb6f59f5c251f48cadc47ea54026441c4a385079286a94fa/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5906bf7718d3636dc13402914736abe723492cb730f744834f5f5b67d3a12702", size = 4664619, upload-time = "2026-05-06T06:18:13.771Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/069542d37946ed08669b127e1496fa99e78196d71de8d41eda5e9f1b7a58/hf_xet-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f3dc2248fc01cc0a00cd392ab497f1ca373fcbc7e3f2da1f452480b384e839e", size = 3966802, upload-time = "2026-05-06T06:18:28.162Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/91/fc6fdec27b14d04e88c386ac0a0129732b53fa23f7c4a78f4b83a039c567/hf_xet-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b285cea1b5bab46b758772716ba8d6854a1a0310fed1c249d678a8b38601e5a0", size = 3797168, upload-time = "2026-05-06T06:18:26.287Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/fb/69ff198a82cae7eb1a69fb84d93b3a3e4816564d76817fe541ddc96874eb/hf_xet-1.5.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dad0dc84e941b8ba3c860659fe1fdc35c049d47cce293f003287757e971a8f56", size = 4030814, upload-time = "2026-05-06T06:17:57.933Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/edcc2b40162bef3ff78e14ab637e5f3b89243d6aee72f5949d3bb6a5af83/hf_xet-1.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd6e5a9b0fdac4ed03ed45ef79254a655b1aaab514a02202617fbf643f5fdf7a", size = 3798444, upload-time = "2026-05-06T06:17:55.79Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4d/103f76b04310e5e57656696cc184690d20c466af0bca3ca88f8c8ea5d4f3/hf_xet-1.5.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3531b1823a0e6d77d80f9ed15ca0e00f0d115094f8ac033d5cae88f4564cc949", size = 4465986, upload-time = "2026-05-06T06:17:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a2/546f47f464737b3edbab6f8ddb57f2599b93d2cbb66f06abb475ccb48651/hf_xet-1.5.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9a0ee58cd18d5ea799f7ed11290bbccbe56bdd8b1d97ca74b9cc49a3945d7a3b", size = 4259865, upload-time = "2026-05-06T06:17:42.639Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7f/1be593c1f28613be2e196473481cd81bfc5910795e30a34e8f744f6cac4f/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e60df5a42e9bed8628b6416af2cba4cba57ae9f02de226a06b020d98e1aab18", size = 4459835, upload-time = "2026-05-06T06:18:08.026Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b2/703569fc881f3284487e68cda7b42179978480da3c438042a6bbbb4a671c/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690", size = 4672414, upload-time = "2026-05-06T06:18:09.864Z" },
+    { url = "https://files.pythonhosted.org/packages/af/37/1b6def445c567286b50aa3b33828158e135b1be44938dde59f11382a500c/hf_xet-1.5.0-cp37-abi3-win_amd64.whl", hash = "sha256:2806c7c17b4d23f8d88f7c4814f838c3b6150773fe339c20af23e1cfaf2797e4", size = 3977238, upload-time = "2026-05-06T06:18:23.621Z" },
+    { url = "https://files.pythonhosted.org/packages/62/94/3b66b148778ee100dcfd69c2ca22b57b41b44d3063ceec934f209e9184ce/hf_xet-1.5.0-cp37-abi3-win_arm64.whl", hash = "sha256:b6c9df403040248c76d808d3e047d64db2d923bae593eb244c41e425cf6cd7be", size = 3806916, upload-time = "2026-05-06T06:18:21.7Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/b6/e22bd20a25299c34b8c5922c1545a6320825b13906eb0f7298edfd034a0b/huggingface_hub-1.15.0.tar.gz", hash = "sha256:28abfdddda3927fd4de6a63cf26ab012498a2c24dae52baf150c5c6edf98a1d5", size = 784100, upload-time = "2026-05-15T11:42:52.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/11/0b64cc9024329b76d7547c19a67604a61d21d3ba678a69d1b220c29d5112/huggingface_hub-1.15.0-py3-none-any.whl", hash = "sha256:a4a59af04cbc41a3fe3fec429b171ef994ef8c971eda10136746f408dd4e3744", size = 663602, upload-time = "2026-05-15T11:42:50.487Z" },
 ]
 
 [[package]]
@@ -2666,6 +2778,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "simplejson"
 version = "3.20.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2783,6 +2904,9 @@ download = [
     { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tensorflow-cpu" },
 ]
+hf = [
+    { name = "huggingface-hub" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2791,6 +2915,7 @@ requires-dist = [
     { name = "gdown", marker = "extra == 'download'", specifier = ">=5.1.0" },
     { name = "grain", specifier = ">=0.2.13" },
     { name = "h5py", specifier = ">=3.13.0" },
+    { name = "huggingface-hub", extras = ["cli", "hf-transfer"], marker = "extra == 'hf'", specifier = ">=0.27" },
     { name = "jax", specifier = ">=0.6.0" },
     { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda12'", specifier = ">=0.6.0" },
     { name = "matplotlib", marker = "extra == 'dev'", specifier = ">=3.10.1" },
@@ -2808,7 +2933,7 @@ requires-dist = [
     { name = "tensorflow-cpu", marker = "extra == 'download'", specifier = ">=2.15.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
 ]
-provides-extras = ["dev", "cuda12", "download"]
+provides-extras = ["dev", "cuda12", "download", "hf"]
 
 [[package]]
 name = "tensorboard"
@@ -3022,6 +3147,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

First of five planned PRs adding Hugging Face Hub as a first-class destination for synthpix-built PIV datasets. **No network operations in this PR** — strictly the foundation that later PRs (`pull`, `push`, `hf://` resolver) build on.

### What this PR adds

| New module | Purpose |
|---|---|
| `src/synthpix/hf/auth.py` | `resolve_token(...)` — precedence: explicit arg → `HF_TOKEN` env → `HF_HUB_TOKEN` env → cached creds via `huggingface_hub.HfFolder.get_token()`. Lazy import; never persists. |
| `src/synthpix/hf/layout.py` | `inspect_local_layout(root)` — counts `.mat` files per split (`train`/`val`/`test`/`tune`), maps non-hidden immediate subdirs (Reynolds numbers or scene names), totals bytes. Tolerates missing splits. |
| `src/synthpix/hf/card.py` | `make_dataset_card(meta, layout)` — YAML frontmatter + body containing source URL, citation, license note, per-split counts, optional subdir map, synthpix version + commit footer. License defaults: `license: other`, `license_name: research-only-arr` to encode the "research only / all rights reserved" stance from the published PIV class-1 source. |
| `src/synthpix/hf/cli.py` | `synthpix-hf card LOCAL_DIR --source-url ... --citation ...` writes a README into `LOCAL_DIR`. `--force` to overwrite. `push`/`pull` subcommands parse but exit with "not yet implemented in PR1" — keeps the CLI surface forward-compatible. |

### Configuration changes

- `pyproject.toml`: new `[project.optional-dependencies] hf = ["huggingface_hub[cli,hf_transfer]>=0.27"]` and `[project.scripts] synthpix-hf = "synthpix.hf.cli:main"`.
- `uv.lock`: refreshed (added `huggingface-hub`, `httpx`, `httpcore`, `shellingham`, `typer` as transitive deps under the `[hf]` extra).
- No changes to runtime deps. Top-level `synthpix` imports work without the extra installed; `huggingface_hub` is imported lazily inside `auth.py` only when cached-creds fallback is needed.

### What this PR explicitly does **not** include

- `push_dataset` / `pull_dataset` (PR2 and PR3)
- `hf://` resolver in `data_sources/` (PR5, stretch)
- Docs page (PR4)
- Any changes to `scripts/download_piv_*.py`

## Why this scope first

PR1 is independently useful: any local synthpix-built dataset directory can already be augmented with a compliant dataset card via `synthpix-hf card`. That alone documents the dataset's provenance + license terms in-tree, which is what's blocking us from putting our private PIV class-1 mirror on the Hub today. The network-touching pieces follow in PR2/PR3 once this is reviewed.

## Test plan

- [x] `tests/hf/test_auth.py` — token-resolution precedence (5 tests + 1 skipped when `huggingface_hub` not installed in dev venv, gated by `pytest.importorskip`)
- [x] `tests/hf/test_layout.py` — split counts, subdir map, dotfile/extras handling, missing-split tolerance
- [x] `tests/hf/test_card.py` — YAML frontmatter parses, license fields, citation, per-split counts, `synthpix_version` auto-fill, `synthpix_commit` auto-fill via mocked subprocess, graceful fallback if subprocess fails
- [x] `tests/hf/test_cli.py` — write README, refuse-overwrite without `--force`, force-overwrite, citation-from-file, custom `--output`, stub messages for `push`/`pull`
- [x] `uv run pytest tests/hf/ -q`: **26 passed, 1 skipped**
- [x] `uv run pre-commit run --files <touched files>`: all hooks pass
- [ ] CI on `dev`: pre-commit + pytest

## Notes for reviewers

- **Field naming**: `LayoutSummary.reynolds_by_split` is named for the original use case (Reynolds-number subdirs) but accepts any immediate non-hidden subdir (PIV class-1 in practice uses scene names like `DNS_turbulence`, `cylinder`, etc.). Forward-compatible.
- **First commit (`578af91`) isn't independently importable** — `hf/__init__.py` re-exports symbols that arrive in commit 2. End state is clean. Only matters if you bisect through these specific four commits.
- **Bandit `# nosec` annotation** on the `git rev-parse HEAD` call in `card.py` — fixed argv, no user input. The suppression is scoped to the line.
- `pre-commit run --all-files` reveals 3 pre-existing mypy errors elsewhere in the repo (`sampler/base.py`, `sampler/synthetic.py`, `data_sources/adapter.py`) — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)