### PR TITLE
feat(hf): PR2/5 — pull_dataset + synthpix-hf pull subcommand

### DIFF
--- a/.pydoclint-baseline
+++ b/.pydoclint-baseline
@@ -63,7 +63,6 @@ tests/conftest.py
     DOC106: Function `pytest_collection_modifyitems`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
     DOC107: Function `pytest_collection_modifyitems`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
     DOC103: Function `pytest_collection_modifyitems`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [config: , items: ].
-    DOC201: Function `pytest_collection_modifyitems` does not have a return section in docstring
     DOC402: Function `clear_after_test` has "yield" statements, but the docstring does not have a "Yields" section
     DOC404: Function `clear_after_test` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
 --------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ markers = [
         "run_explicitly: marks tests that are only run with -m run_explicitly",
         "slow: marks tests as slow (deselect with '-m \"not slow\"')",
         "to_fix: marks tests that need fixing (deselect with '-m \"not to_fix\"')",
+        "hf_live: marks tests that exercise the live Hugging Face Hub (deselect by default; opt in with --run-hf-live)",
 ]
 
 # Ruff configuration for linting and modern typing enforcement

--- a/src/synthpix/hf/__init__.py
+++ b/src/synthpix/hf/__init__.py
@@ -1,19 +1,21 @@
 """Hugging Face Hub integration for the ``synthpix`` package.
 
-This subpackage exposes only metadata and layout helpers in PR1. Network
-operations (push/pull) are deferred to subsequent PRs. ``huggingface_hub`` is
-imported lazily inside :mod:`synthpix.hf.auth`, so this module remains usable
-without the ``[hf]`` optional extra installed.
+This subpackage exposes metadata helpers, layout introspection, and the
+``pull_dataset`` downloader. ``huggingface_hub`` is imported lazily inside
+:mod:`synthpix.hf.auth` and :mod:`synthpix.hf.pull`, so this module remains
+usable without the ``[hf]`` optional extra installed.
 """
 
 from synthpix.hf.auth import resolve_token
 from synthpix.hf.card import DatasetCardMeta, make_dataset_card
 from synthpix.hf.layout import LayoutSummary, inspect_local_layout
+from synthpix.hf.pull import pull_dataset
 
 __all__ = [
     "DatasetCardMeta",
     "LayoutSummary",
     "inspect_local_layout",
     "make_dataset_card",
+    "pull_dataset",
     "resolve_token",
 ]

--- a/src/synthpix/hf/_transfer.py
+++ b/src/synthpix/hf/_transfer.py
@@ -1,10 +1,13 @@
 """Internal helpers to toggle ``hf_transfer`` acceleration.
 
-``hf_transfer`` is a Rust-backed download accelerator shipped via the
-``huggingface_hub[hf_transfer]`` extra. When the library is importable we
-opt in by setting ``HF_HUB_ENABLE_HF_TRANSFER=1`` for the duration of a
-block. The probe uses :func:`importlib.util.find_spec` so we never pull
-``hf_transfer`` into the module graph eagerly.
+``hf_transfer`` is a Rust-backed download accelerator. When the library is
+importable we opt in by setting ``HF_HUB_ENABLE_HF_TRANSFER=1`` for the
+duration of a block. The probe uses :func:`importlib.util.find_spec` so we
+never pull ``hf_transfer`` into the module graph eagerly.
+
+The toggle is reentrant: nested ``enable_hf_transfer()`` blocks reference-
+count the env mutation under a process-local lock, so overlapping callers
+cannot leak the flag or restore it in the wrong order.
 """
 
 from __future__ import annotations
@@ -12,6 +15,7 @@ from __future__ import annotations
 import contextlib
 import importlib.util
 import os
+import threading
 from collections.abc import Iterator
 
 from synthpix.utils import SYNTHPIX_SCOPE, get_logger
@@ -19,6 +23,17 @@ from synthpix.utils import SYNTHPIX_SCOPE, get_logger
 logger = get_logger(__name__, scope=SYNTHPIX_SCOPE)
 
 _ENV_FLAG = "HF_HUB_ENABLE_HF_TRANSFER"
+
+# Reentrancy + thread-safety state. ``_state_lock`` serializes mutations of
+# the env flag across overlapping ``enable_hf_transfer`` contexts in the same
+# process. ``_active_count`` tracks how many contexts are currently inside
+# the "set" branch so the outermost exit is the one that restores the prior
+# value. ``_saved_value`` holds whatever ``os.environ`` had when the first
+# context entered (``None`` means "absent").
+_state_lock = threading.Lock()
+_active_count = 0
+_saved_value: str | None = None
+_saved_present = False
 
 
 def _hf_transfer_available() -> bool:
@@ -36,29 +51,54 @@ def enable_hf_transfer() -> Iterator[None]:
     """Toggle ``HF_HUB_ENABLE_HF_TRANSFER`` for the duration of the block.
 
     The previous value of the environment variable (or its absence) is
-    restored on exit. If ``hf_transfer`` is not installed, the helper logs a
-    one-line warning and yields without mutating the environment, so the
-    caller transparently falls back to ``huggingface_hub``'s plain
-    downloader.
+    restored when the outermost enclosing context exits. Nested calls in the
+    same process share the same saved value, so an interior exit does not
+    pop the flag out from under a still-active outer context.
+
+    When ``hf_transfer`` is not installed the helper logs a one-line warning
+    and *clears* any stale ``HF_HUB_ENABLE_HF_TRANSFER=1`` inherited from
+    the environment for the duration of the block. This guarantees the
+    documented "transparently fall back to the standard downloader"
+    behavior: ``huggingface_hub`` cannot then attempt the accelerated path
+    and fail with a confusing ``ImportError`` from inside the download.
 
     Yields:
         None: The context payload; callers do not need the value.
     """
+    global _active_count, _saved_value, _saved_present
+
     if not _hf_transfer_available():
         logger.warning(
             "hf_transfer is not installed; falling back to the standard "
-            "huggingface_hub downloader. Install with `pip install "
-            "synthpix[hf]` for accelerated transfers."
+            "huggingface_hub downloader. Install with "
+            "`pip install synthpix[hf]` for accelerated transfers."
         )
-        yield
+        with _state_lock:
+            previous = os.environ.pop(_ENV_FLAG, None)
+        try:
+            yield
+        finally:
+            with _state_lock:
+                if previous is not None:
+                    os.environ[_ENV_FLAG] = previous
         return
 
-    previous = os.environ.get(_ENV_FLAG)
-    os.environ[_ENV_FLAG] = "1"
+    with _state_lock:
+        if _active_count == 0:
+            _saved_present = _ENV_FLAG in os.environ
+            _saved_value = os.environ.get(_ENV_FLAG)
+            os.environ[_ENV_FLAG] = "1"
+        _active_count += 1
+
     try:
         yield
     finally:
-        if previous is None:
-            os.environ.pop(_ENV_FLAG, None)
-        else:
-            os.environ[_ENV_FLAG] = previous
+        with _state_lock:
+            _active_count -= 1
+            if _active_count == 0:
+                if _saved_present:
+                    os.environ[_ENV_FLAG] = _saved_value or ""
+                else:
+                    os.environ.pop(_ENV_FLAG, None)
+                _saved_value = None
+                _saved_present = False

--- a/src/synthpix/hf/_transfer.py
+++ b/src/synthpix/hf/_transfer.py
@@ -1,0 +1,64 @@
+"""Internal helpers to toggle ``hf_transfer`` acceleration.
+
+``hf_transfer`` is a Rust-backed download accelerator shipped via the
+``huggingface_hub[hf_transfer]`` extra. When the library is importable we
+opt in by setting ``HF_HUB_ENABLE_HF_TRANSFER=1`` for the duration of a
+block. The probe uses :func:`importlib.util.find_spec` so we never pull
+``hf_transfer`` into the module graph eagerly.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import os
+from collections.abc import Iterator
+
+from synthpix.utils import SYNTHPIX_SCOPE, get_logger
+
+logger = get_logger(__name__, scope=SYNTHPIX_SCOPE)
+
+_ENV_FLAG = "HF_HUB_ENABLE_HF_TRANSFER"
+
+
+def _hf_transfer_available() -> bool:
+    """Return whether ``hf_transfer`` is importable without importing it.
+
+    Returns:
+        bool: ``True`` when :func:`importlib.util.find_spec` locates the
+            ``hf_transfer`` package, otherwise ``False``.
+    """
+    return importlib.util.find_spec("hf_transfer") is not None
+
+
+@contextlib.contextmanager
+def enable_hf_transfer() -> Iterator[None]:
+    """Toggle ``HF_HUB_ENABLE_HF_TRANSFER`` for the duration of the block.
+
+    The previous value of the environment variable (or its absence) is
+    restored on exit. If ``hf_transfer`` is not installed, the helper logs a
+    one-line warning and yields without mutating the environment, so the
+    caller transparently falls back to ``huggingface_hub``'s plain
+    downloader.
+
+    Yields:
+        None: The context payload; callers do not need the value.
+    """
+    if not _hf_transfer_available():
+        logger.warning(
+            "hf_transfer is not installed; falling back to the standard "
+            "huggingface_hub downloader. Install with `pip install "
+            "synthpix[hf]` for accelerated transfers."
+        )
+        yield
+        return
+
+    previous = os.environ.get(_ENV_FLAG)
+    os.environ[_ENV_FLAG] = "1"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(_ENV_FLAG, None)
+        else:
+            os.environ[_ENV_FLAG] = previous

--- a/src/synthpix/hf/cli.py
+++ b/src/synthpix/hf/cli.py
@@ -90,6 +90,21 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _read_citation(value: str) -> str:
+    """Return the citation contents, reading from disk if ``value`` is a path.
+
+    Used by the ``push`` subcommand's single ``--card-citation`` flag,
+    where the value may be either a literal citation string or a path
+    to a file containing it. The ``card`` subcommand instead uses an
+    explicit mutually-exclusive ``--citation``/``--citation-file`` pair
+    via :func:`_resolve_citation` below.
+    """
+    candidate = Path(value)
+    if candidate.is_file():
+        return candidate.read_text()
+    return value
+
+
 def _resolve_citation(args: argparse.Namespace) -> str:
     """Return the citation contents from the chosen mutually exclusive flag.
 

--- a/src/synthpix/hf/cli.py
+++ b/src/synthpix/hf/cli.py
@@ -3,18 +3,20 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
 from synthpix.hf.card import DatasetCardMeta, make_dataset_card
 from synthpix.hf.layout import inspect_local_layout
+from synthpix.hf.pull import pull_dataset
 from synthpix.utils import SYNTHPIX_SCOPE, get_logger
 
 logger = get_logger(__name__, scope=SYNTHPIX_SCOPE)
 
 _NOT_IMPLEMENTED = (
-    "This subcommand is not yet implemented in PR1. "
-    "Stay tuned for the upcoming push/pull rollouts."
+    "This subcommand is not yet implemented. "
+    "Stay tuned for the upcoming push rollout."
 )
 
 
@@ -47,13 +49,35 @@ def _build_parser() -> argparse.ArgumentParser:
     card.add_argument("--output", type=Path, default=None)
     card.add_argument("--force", action="store_true")
 
-    push = sub.add_parser("push", help="(PR2) Push a dataset to the Hub.")
+    push = sub.add_parser("push", help="(PR3) Push a dataset to the Hub.")
     push.add_argument("local_dir", nargs="?", default=None)
     push.add_argument("--repo-id", default=None)
 
-    pull = sub.add_parser("pull", help="(PR3) Pull a dataset from the Hub.")
-    pull.add_argument("repo_id", nargs="?", default=None)
-    pull.add_argument("--local-dir", default=None)
+    pull = sub.add_parser("pull", help="Pull a dataset from the Hub.")
+    pull.add_argument("repo_id")
+    pull.add_argument("local_dir", type=Path)
+    pull.add_argument("--revision", default="main")
+    pull.add_argument("--token", default=None)
+    pull.add_argument(
+        "--splits",
+        default=None,
+        help="Comma-separated split names to download (e.g. train,val).",
+    )
+    pull.add_argument(
+        "--include",
+        action="append",
+        default=None,
+        metavar="PATTERN",
+        help="Allow-list glob; may be repeated. Wins over --splits.",
+    )
+    pull.add_argument(
+        "--ignore",
+        action="append",
+        default=None,
+        metavar="PATTERN",
+        help="Deny-list glob; may be repeated.",
+    )
+    pull.add_argument("--max-workers", type=int, default=8)
 
     return parser
 
@@ -103,6 +127,72 @@ def _run_card(args: argparse.Namespace) -> int:
     return 0
 
 
+def _parse_splits(raw: str | None) -> tuple[str, ...] | None:
+    if raw is None:
+        return None
+    return tuple(part for part in raw.split(",") if part)
+
+
+def _human_bytes(num: float) -> str:
+    # IEC suffixes (1 KiB == 1024 B). Falls through to PiB for >1024 TiB.
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if num < 1024.0:
+            return f"{num:.1f} {unit}"
+        num /= 1024.0
+    return f"{num:.1f} PiB"
+
+
+def _summarize_target(target: Path) -> tuple[int, int]:
+    # Returns (file_count, total_bytes). Uses inspect_local_layout when the
+    # tree matches the train/val/test/tune convention; otherwise falls back
+    # to a plain os.walk so non-PIV repos still get a useful summary line.
+    try:
+        layout = inspect_local_layout(target)
+    except (FileNotFoundError, NotADirectoryError):
+        return 0, 0
+
+    if layout.splits:
+        return (layout.mat_files + layout.extra_files, layout.total_bytes)
+
+    files = 0
+    total_bytes = 0
+    for dirpath, _, filenames in os.walk(target):
+        for name in filenames:
+            files += 1
+            try:
+                total_bytes += (Path(dirpath) / name).stat().st_size
+            except OSError:
+                continue
+    return files, total_bytes
+
+
+def _run_pull(args: argparse.Namespace) -> int:
+    splits = _parse_splits(args.splits)
+    include_globs = tuple(args.include) if args.include is not None else None
+    kwargs: dict = {
+        "revision": args.revision,
+        "token": args.token,
+        "splits": splits,
+        "include_globs": include_globs,
+        "max_workers": args.max_workers,
+    }
+    if args.ignore is not None:
+        kwargs["ignore_globs"] = tuple(args.ignore)
+
+    try:
+        target = pull_dataset(args.repo_id, args.local_dir, **kwargs)
+    except Exception as exc:
+        print(f"synthpix-hf pull: {exc}", file=sys.stderr)
+        return 1
+
+    files, total_bytes = _summarize_target(target)
+    print(
+        f"Pulled {args.repo_id}@{args.revision} -> {target} "
+        f"({files} files, {_human_bytes(total_bytes)})"
+    )
+    return 0
+
+
 def _run_stub(name: str) -> int:
     print(f"`synthpix-hf {name}`: {_NOT_IMPLEMENTED}", file=sys.stderr)
     return 2
@@ -122,7 +212,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "card":
         return _run_card(args)
-    if args.command in {"push", "pull"}:
+    if args.command == "pull":
+        return _run_pull(args)
+    if args.command == "push":
         return _run_stub(args.command)
 
     # ``add_subparsers(required=True)`` makes this unreachable; ``parser.error``

--- a/src/synthpix/hf/cli.py
+++ b/src/synthpix/hf/cli.py
@@ -57,7 +57,15 @@ def _build_parser() -> argparse.ArgumentParser:
     pull.add_argument("repo_id")
     pull.add_argument("local_dir", type=Path)
     pull.add_argument("--revision", default="main")
-    pull.add_argument("--token", default=None)
+    pull.add_argument(
+        "--token",
+        default=None,
+        help=(
+            "HF token. Prefer the HF_TOKEN / HF_HUB_TOKEN environment "
+            "variables or `hf auth login` — values passed on the command "
+            "line are visible in shell history and process listings."
+        ),
+    )
     pull.add_argument(
         "--splits",
         default=None,
@@ -128,9 +136,13 @@ def _run_card(args: argparse.Namespace) -> int:
 
 
 def _parse_splits(raw: str | None) -> tuple[str, ...] | None:
+    # Strip and reject empties so inputs like "train, val" or ",val," still
+    # map to the intended ("train", "val") filter instead of synthesizing
+    # bogus " val/**" patterns that silently skip the requested split.
     if raw is None:
         return None
-    return tuple(part for part in raw.split(",") if part)
+    parts = tuple(part.strip() for part in raw.split(",") if part.strip())
+    return parts if parts else None
 
 
 def _human_bytes(num: float) -> str:
@@ -143,16 +155,14 @@ def _human_bytes(num: float) -> str:
 
 
 def _summarize_target(target: Path) -> tuple[int, int]:
-    # Returns (file_count, total_bytes). Uses inspect_local_layout when the
-    # tree matches the train/val/test/tune convention; otherwise falls back
-    # to a plain os.walk so non-PIV repos still get a useful summary line.
-    try:
-        layout = inspect_local_layout(target)
-    except (FileNotFoundError, NotADirectoryError):
+    # Returns (file_count, total_bytes) for the actually-downloaded tree.
+    # Walks the directory directly instead of going through
+    # ``inspect_local_layout``: that helper only sees files inside the
+    # recognized split folders and would otherwise undercount root-level
+    # files like ``README.md`` that ``pull_dataset`` is expected to bring
+    # along when ``splits`` is set.
+    if not target.exists():
         return 0, 0
-
-    if layout.splits:
-        return (layout.mat_files + layout.extra_files, layout.total_bytes)
 
     files = 0
     total_bytes = 0

--- a/src/synthpix/hf/pull.py
+++ b/src/synthpix/hf/pull.py
@@ -1,0 +1,138 @@
+"""Download synthpix-hosted PIV datasets from the Hugging Face Hub.
+
+The public entry point is :func:`pull_dataset`, a thin wrapper around
+``huggingface_hub.snapshot_download`` that:
+
+* lazy-imports ``huggingface_hub`` so the package keeps working without the
+  ``[hf]`` extra installed;
+* resolves a token via :func:`synthpix.hf.auth.resolve_token`;
+* turns the ``splits`` shorthand into ``allow_patterns`` so callers can ask
+  for a subset of a dataset without learning glob syntax;
+* enables ``hf_transfer`` acceleration when available via
+  :func:`synthpix.hf._transfer.enable_hf_transfer`.
+
+The resulting on-disk tree mirrors the repo and is consumable directly by
+the ``.mat`` schedulers without an extra symlink resolution step.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+from synthpix.hf._transfer import enable_hf_transfer
+from synthpix.hf.auth import resolve_token
+from synthpix.utils import SYNTHPIX_SCOPE, get_logger
+
+logger = get_logger(__name__, scope=SYNTHPIX_SCOPE)
+
+_DEFAULT_IGNORE: tuple[str, ...] = (
+    "**/.DS_Store",
+    "**/__pycache__/**",
+    "**/.git/**",
+)
+
+
+def _resolve_allow_patterns(
+    splits: tuple[str, ...] | None,
+    include_globs: tuple[str, ...] | None,
+) -> list[str] | None:
+    """Translate the user-facing filters into ``allow_patterns``.
+
+    Explicit ``include_globs`` always win. When only ``splits`` is provided
+    we synthesize ``"<split>/**"`` patterns and always append ``README.md``
+    so the dataset card travels with the data.
+
+    Args:
+        splits: Split names to download, or ``None`` for no split filter.
+        include_globs: Explicit allow-list glob patterns. Takes precedence
+            over ``splits`` and triggers a warning when both are set.
+
+    Returns:
+        list[str] | None: The patterns to pass to
+            ``snapshot_download``'s ``allow_patterns``, or ``None`` when
+            both inputs are unset (download everything).
+    """
+    if include_globs is not None:
+        if splits is not None:
+            logger.warning(
+                "Both `splits` and `include_globs` were provided; "
+                "ignoring `splits` and honoring the explicit globs."
+            )
+        return list(include_globs)
+    if splits is not None:
+        return [f"{name}/**" for name in splits] + ["README.md"]
+    return None
+
+
+def pull_dataset(
+    repo_id: str,
+    local_dir: str | Path,
+    *,
+    revision: str = "main",
+    token: str | None = None,
+    splits: tuple[str, ...] | None = None,
+    include_globs: tuple[str, ...] | None = None,
+    ignore_globs: tuple[str, ...] = _DEFAULT_IGNORE,
+    max_workers: int = 8,
+) -> Path:
+    """Download an HF Hub dataset repo into ``local_dir``.
+
+    The transfer goes through ``huggingface_hub.snapshot_download`` and is
+    therefore resumable and idempotent: an existing ``local_dir`` is reused
+    rather than wiped. Symlinks are disabled so the resulting tree mirrors
+    the repo and can be fed directly into ``.mat`` schedulers.
+
+    Args:
+        repo_id: ``<org>/<dataset>`` identifier on the Hub.
+        local_dir: Destination directory; created if it does not exist.
+            Tilde expansion is applied.
+        revision: Git-style revision (branch, tag, or commit) to download.
+        token: Explicit Hugging Face token. When ``None``, the standard
+            resolution chain (env vars, cached token) is used. Public
+            datasets work without a token.
+        splits: Convenience filter for split-style layouts; when set,
+            ``allow_patterns`` becomes ``("<split>/**", ..., "README.md")``.
+            Ignored if ``include_globs`` is also given.
+        include_globs: Explicit glob allow-list; takes precedence over
+            ``splits``.
+        ignore_globs: Glob deny-list applied after ``include_globs``.
+        max_workers: Parallel download workers.
+
+    Returns:
+        Path: The resolved local path, equivalent to
+            ``Path(local_dir).expanduser().resolve()``.
+
+    Raises:
+        ImportError: If ``huggingface_hub`` is not installed.
+        NotADirectoryError: If ``local_dir`` exists and is a regular file.
+    """
+    target = Path(local_dir).expanduser()
+    if target.exists() and not target.is_dir():
+        raise NotADirectoryError(
+            f"local_dir exists and is not a directory: {target}"
+        )
+
+    try:
+        hub = importlib.import_module("huggingface_hub")
+    except ImportError as exc:
+        raise ImportError(
+            "huggingface_hub is required for synthpix.hf.pull_dataset; "
+            "install with `pip install synthpix[hf]`"
+        ) from exc
+    resolved_token = resolve_token(token)
+    allow_patterns = _resolve_allow_patterns(splits, include_globs)
+
+    with enable_hf_transfer():
+        hub.snapshot_download(
+            repo_id=repo_id,
+            repo_type="dataset",
+            revision=revision,
+            local_dir=str(target),
+            token=resolved_token,
+            allow_patterns=allow_patterns,
+            ignore_patterns=list(ignore_globs),
+            max_workers=max_workers,
+        )
+
+    return target.resolve()

--- a/src/synthpix/hf/pull.py
+++ b/src/synthpix/hf/pull.py
@@ -113,17 +113,22 @@ def pull_dataset(
             f"local_dir exists and is not a directory: {target}"
         )
 
-    try:
-        hub = importlib.import_module("huggingface_hub")
-    except ImportError as exc:
-        raise ImportError(
-            "huggingface_hub is required for synthpix.hf.pull_dataset; "
-            "install with `pip install synthpix[hf]`"
-        ) from exc
     resolved_token = resolve_token(token)
     allow_patterns = _resolve_allow_patterns(splits, include_globs)
 
+    # ``huggingface_hub`` reads ``HF_HUB_ENABLE_HF_TRANSFER`` into its module
+    # constants at *import* time, so we must enter ``enable_hf_transfer()``
+    # before the import — otherwise the accelerated path stays off even when
+    # the library is installed.
     with enable_hf_transfer():
+        try:
+            hub = importlib.import_module("huggingface_hub")
+        except ImportError as exc:
+            raise ImportError(
+                "huggingface_hub is required for synthpix.hf.pull_dataset; "
+                "install with `pip install synthpix[hf]`"
+            ) from exc
+
         hub.snapshot_download(
             repo_id=repo_id,
             repo_type="dataset",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,14 +234,21 @@ def pytest_addoption(parser):
 # ──────────────────────────────────────────────────────────────────────────────
 def pytest_collection_modifyitems(config, items):
     """Skip tests unless explicitly selected with -m run_explicitly."""
-    if config.getoption("-m") and "run_explicitly" in config.getoption("-m"):
-        return
-    skip = pytest.mark.skip(
+    explicit_marker = (
+        config.getoption("-m") and "run_explicitly" in config.getoption("-m")
+    )
+    run_hf_live = config.getoption("--run-hf-live", default=False)
+    skip_explicit = pytest.mark.skip(
         reason="Skipped unless explicitly selected with -m run_explicitly"
     )
+    skip_hf_live = pytest.mark.skip(
+        reason="Skipped unless --run-hf-live is passed on the CLI"
+    )
     for item in items:
-        if "run_explicitly" in item.keywords:
-            item.add_marker(skip)
+        if "run_explicitly" in item.keywords and not explicit_marker:
+            item.add_marker(skip_explicit)
+        if "hf_live" in item.keywords and not run_hf_live:
+            item.add_marker(skip_hf_live)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -217,6 +217,19 @@ def mock_mat_files(tmp_path, mat_test_dims, request):
 
 
 # ──────────────────────────────────────────────────────────────────────────────
+# CLI options
+# ──────────────────────────────────────────────────────────────────────────────
+def pytest_addoption(parser):
+    # Register custom command-line options for the test suite.
+    parser.addoption(
+        "--run-hf-live",
+        action="store_true",
+        default=False,
+        help="Run the gated Hugging Face live tests (network access).",
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
 # Collection modifier
 # ──────────────────────────────────────────────────────────────────────────────
 def pytest_collection_modifyitems(config, items):

--- a/tests/hf/test_cli.py
+++ b/tests/hf/test_cli.py
@@ -267,6 +267,88 @@ def test_cli_pull_exit_nonzero_on_runtime_error(
     assert "boom!" in captured.err
 
 
+def test_cli_pull_splits_strips_whitespace(monkeypatch, tmp_path: Path):
+    captured: dict = {}
+
+    def _fake(repo_id, local_dir, **kwargs):
+        captured.update(kwargs)
+        Path(local_dir).mkdir(parents=True, exist_ok=True)
+        return Path(local_dir)
+
+    monkeypatch.setattr(cli, "pull_dataset", _fake)
+
+    rc = cli.main(
+        [
+            "pull",
+            "user/repo",
+            str(tmp_path / "data"),
+            "--splits",
+            "train, val ,  ,test",
+        ]
+    )
+
+    assert rc == 0
+    # Whitespace stripped, empty parts dropped.
+    assert captured["splits"] == ("train", "val", "test")
+
+
+def test_cli_pull_splits_all_empty_becomes_none(monkeypatch, tmp_path: Path):
+    captured: dict = {}
+
+    def _fake(repo_id, local_dir, **kwargs):
+        captured.update(kwargs)
+        Path(local_dir).mkdir(parents=True, exist_ok=True)
+        return Path(local_dir)
+
+    monkeypatch.setattr(cli, "pull_dataset", _fake)
+
+    rc = cli.main(
+        [
+            "pull",
+            "user/repo",
+            str(tmp_path / "data"),
+            "--splits",
+            " , , ",
+        ]
+    )
+
+    assert rc == 0
+    assert captured["splits"] is None
+
+
+def test_cli_pull_summary_counts_root_files(
+    monkeypatch, tmp_path: Path, capsys
+):
+    # The summary line must count root-level files (e.g. README.md) that
+    # ``pull_dataset(..., splits=...)`` brings along, not just files under
+    # the recognized split directories.
+    target = tmp_path / "data"
+
+    def _fake(repo_id, local_dir, **_kwargs):
+        local = Path(local_dir)
+        (local / "train").mkdir(parents=True, exist_ok=True)
+        (local / "train" / "a.mat").write_bytes(b"x" * 4)
+        (local / "README.md").write_text("# card")
+        return local
+
+    monkeypatch.setattr(cli, "pull_dataset", _fake)
+
+    rc = cli.main(
+        [
+            "pull",
+            "user/repo",
+            str(target),
+            "--splits",
+            "train",
+        ]
+    )
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    # 1 .mat + 1 README.md = 2 files
+    assert "2 files" in out
+
+
 def test_cli_pull_token_not_logged(
     monkeypatch, tmp_path: Path, capsys, caplog
 ):

--- a/tests/hf/test_cli.py
+++ b/tests/hf/test_cli.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from synthpix.hf import cli
 
 

--- a/tests/hf/test_cli.py
+++ b/tests/hf/test_cli.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from synthpix.hf import cli
 
 
 def _populate(tmp_path: Path) -> None:
-    """Drop a single ``.mat`` file so ``inspect_local_layout`` succeeds."""
+    # Drop a single ``.mat`` file so ``inspect_local_layout`` succeeds.
     train = tmp_path / "train"
     train.mkdir()
     (train / "flow.mat").write_bytes(b"x" * 8)
@@ -188,12 +186,109 @@ def test_card_subcommand_respects_output(tmp_path: Path):
     assert not (tmp_path / "README.md").exists()
 
 
-@pytest.mark.parametrize("subcommand", ["push", "pull"])
-def test_stub_subcommands_report_not_implemented(
-    subcommand: str, capsys
-):
-    rc = cli.main([subcommand])
+def test_push_subcommand_reports_not_implemented(capsys):
+    rc = cli.main(["push"])
 
     captured = capsys.readouterr()
     assert rc != 0
     assert "not yet implemented" in (captured.out + captured.err).lower()
+
+
+def test_cli_pull_invokes_pull_dataset(monkeypatch, tmp_path: Path):
+    captured: dict = {}
+
+    def _fake(repo_id, local_dir, **kwargs):
+        captured["repo_id"] = repo_id
+        captured["local_dir"] = local_dir
+        captured.update(kwargs)
+        Path(local_dir).mkdir(parents=True, exist_ok=True)
+        return Path(local_dir)
+
+    monkeypatch.setattr(cli, "pull_dataset", _fake)
+
+    rc = cli.main(
+        [
+            "pull",
+            "user/repo",
+            str(tmp_path / "data"),
+            "--revision",
+            "v1",
+            "--splits",
+            "train,val",
+        ]
+    )
+
+    assert rc == 0
+    assert captured["repo_id"] == "user/repo"
+    assert captured["local_dir"] == tmp_path / "data"
+    assert captured["revision"] == "v1"
+    assert captured["splits"] == ("train", "val")
+    assert captured["token"] is None
+
+
+def test_cli_pull_multiple_include_flags(monkeypatch, tmp_path: Path):
+    captured: dict = {}
+
+    def _fake(repo_id, local_dir, **kwargs):
+        captured.update(kwargs)
+        Path(local_dir).mkdir(parents=True, exist_ok=True)
+        return Path(local_dir)
+
+    monkeypatch.setattr(cli, "pull_dataset", _fake)
+
+    rc = cli.main(
+        [
+            "pull",
+            "user/repo",
+            str(tmp_path / "data"),
+            "--include",
+            "train/**",
+            "--include",
+            "val/**",
+        ]
+    )
+
+    assert rc == 0
+    assert captured["include_globs"] == ("train/**", "val/**")
+
+
+def test_cli_pull_exit_nonzero_on_runtime_error(
+    monkeypatch, tmp_path: Path, capsys
+):
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("boom!")
+
+    monkeypatch.setattr(cli, "pull_dataset", _boom)
+
+    rc = cli.main(["pull", "user/repo", str(tmp_path / "data")])
+
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert "boom!" in captured.err
+
+
+def test_cli_pull_token_not_logged(
+    monkeypatch, tmp_path: Path, capsys, caplog
+):
+    def _fake(repo_id, local_dir, **_kwargs):
+        Path(local_dir).mkdir(parents=True, exist_ok=True)
+        return Path(local_dir)
+
+    monkeypatch.setattr(cli, "pull_dataset", _fake)
+
+    rc = cli.main(
+        [
+            "pull",
+            "user/repo",
+            str(tmp_path / "data"),
+            "--token",
+            "hf_secret",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "hf_secret" not in captured.out
+    assert "hf_secret" not in captured.err
+    for record in caplog.records:
+        assert "hf_secret" not in record.getMessage()

--- a/tests/hf/test_pull.py
+++ b/tests/hf/test_pull.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from synthpix.hf import auth as auth_mod
 from synthpix.hf import pull as pull_mod
 
 
@@ -51,6 +52,11 @@ def _install_fake_hub(monkeypatch) -> _FakeHub:
 def _clear_env(monkeypatch) -> None:
     monkeypatch.delenv("HF_TOKEN", raising=False)
     monkeypatch.delenv("HF_HUB_TOKEN", raising=False)
+    # Neutralize the on-disk cached token so token resolution is
+    # hermetic regardless of whether the dev machine has run
+    # ``hf auth login``. Env-var and explicit-token resolution paths
+    # are intentionally left intact.
+    monkeypatch.setattr(auth_mod, "_cached_token", lambda: None)
 
 
 def test_pull_dataset_basic(monkeypatch, tmp_path):

--- a/tests/hf/test_pull.py
+++ b/tests/hf/test_pull.py
@@ -199,6 +199,43 @@ def test_pull_dataset_explicit_ignore_globs(monkeypatch, tmp_path):
     assert fake.calls[-1]["ignore_patterns"] == ["**/skip.me"]
 
 
+def test_pull_dataset_enables_hf_transfer_before_import(
+    monkeypatch, tmp_path
+):
+    # huggingface_hub reads HF_HUB_ENABLE_HF_TRANSFER at *import* time,
+    # so the env flag must be set BEFORE the lazy import. Capture the
+    # environment as the import call runs and verify the flag was already
+    # present.
+    import os as _os
+
+    from synthpix.hf import _transfer as transfer_mod
+
+    _clear_env(monkeypatch)
+    monkeypatch.delenv("HF_HUB_ENABLE_HF_TRANSFER", raising=False)
+    monkeypatch.setattr(transfer_mod, "_hf_transfer_available", lambda: True)
+
+    seen_flag: dict[str, bool] = {}
+    fake = _FakeHub()
+    real_import_module = importlib.import_module
+
+    def _import_module(name, package=None):
+        if name == "huggingface_hub":
+            seen_flag["set"] = (
+                _os.environ.get("HF_HUB_ENABLE_HF_TRANSFER") == "1"
+            )
+            return fake
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(pull_mod.importlib, "import_module", _import_module)
+
+    pull_mod.pull_dataset("user/repo", tmp_path / "data")
+
+    assert seen_flag.get("set"), (
+        "HF_HUB_ENABLE_HF_TRANSFER must be set before huggingface_hub "
+        "is imported, otherwise the accelerated path stays off."
+    )
+
+
 # Sanity check: the helper does not pull huggingface_hub into the module
 # graph eagerly.
 def test_pull_module_does_not_eagerly_import_hub():

--- a/tests/hf/test_pull.py
+++ b/tests/hf/test_pull.py
@@ -1,0 +1,202 @@
+"""Tests for ``synthpix.hf.pull.pull_dataset``.
+
+All network access is mocked. The real ``huggingface_hub`` module is
+replaced with a stand-in that records the kwargs passed to
+``snapshot_download``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import types
+from pathlib import Path
+
+import pytest
+
+from synthpix.hf import pull as pull_mod
+
+
+class _FakeHub:
+    """Minimal stand-in for the ``huggingface_hub`` module."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def snapshot_download(self, **kwargs):
+        self.calls.append(kwargs)
+        # Materialize the target so resolved paths are well-defined.
+        local_dir = kwargs.get("local_dir")
+        if local_dir is not None:
+            Path(local_dir).mkdir(parents=True, exist_ok=True)
+        return str(local_dir)
+
+
+def _install_fake_hub(monkeypatch) -> _FakeHub:
+    # Patch ``importlib.import_module`` so the lazy import yields a fake.
+    fake = _FakeHub()
+
+    real_import_module = importlib.import_module
+
+    def _import_module(name, package=None):
+        if name == "huggingface_hub":
+            return fake
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(
+        pull_mod.importlib, "import_module", _import_module
+    )
+    return fake
+
+
+def _clear_env(monkeypatch) -> None:
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HF_HUB_TOKEN", raising=False)
+
+
+def test_pull_dataset_basic(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    fake = _install_fake_hub(monkeypatch)
+
+    result = pull_mod.pull_dataset("user/repo", tmp_path / "data")
+
+    assert isinstance(result, Path)
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    assert call["repo_id"] == "user/repo"
+    assert call["repo_type"] == "dataset"
+    assert call["revision"] == "main"
+    assert call["local_dir"] == str(tmp_path / "data")
+    assert call["allow_patterns"] is None
+    assert call["ignore_patterns"] == list(pull_mod._DEFAULT_IGNORE)
+    assert call["max_workers"] == 8
+
+
+def test_pull_dataset_splits_filter(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    fake = _install_fake_hub(monkeypatch)
+
+    pull_mod.pull_dataset(
+        "user/repo",
+        tmp_path / "data",
+        splits=("train", "val"),
+    )
+
+    call = fake.calls[0]
+    assert call["allow_patterns"] == ["train/**", "val/**", "README.md"]
+
+
+def test_pull_dataset_explicit_includes_win(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    fake = _install_fake_hub(monkeypatch)
+
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        pull_mod.logger,
+        "warning",
+        lambda msg, *a, **kw: warnings.append(msg),
+    )
+
+    pull_mod.pull_dataset(
+        "user/repo",
+        tmp_path / "data",
+        splits=("train",),
+        include_globs=("foo/**",),
+    )
+
+    call = fake.calls[0]
+    assert call["allow_patterns"] == ["foo/**"]
+    assert warnings, "Expected a warning about splits being ignored"
+    assert "splits" in warnings[0].lower()
+
+
+def test_pull_dataset_token_passes_through(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    fake = _install_fake_hub(monkeypatch)
+
+    pull_mod.pull_dataset(
+        "user/repo", tmp_path / "with_token", token="hf_xxx"
+    )
+    assert fake.calls[-1]["token"] == "hf_xxx"
+
+    pull_mod.pull_dataset("user/repo", tmp_path / "no_token")
+    assert fake.calls[-1]["token"] is None
+
+
+def test_pull_dataset_token_resolved_from_env(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HF_TOKEN", "hf_env")
+    fake = _install_fake_hub(monkeypatch)
+
+    pull_mod.pull_dataset("user/repo", tmp_path / "data")
+
+    assert fake.calls[-1]["token"] == "hf_env"
+
+
+def test_pull_dataset_returns_resolved_path(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+
+    target = tmp_path / "nested" / "data"
+    result = pull_mod.pull_dataset("user/repo", target)
+
+    assert result == target.expanduser().resolve()
+
+
+def test_pull_dataset_target_is_file_raises(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+
+    bad = tmp_path / "file"
+    bad.write_bytes(b"not a dir")
+
+    with pytest.raises(NotADirectoryError):
+        pull_mod.pull_dataset("user/repo", bad)
+
+
+def test_pull_dataset_hf_not_installed(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+
+    def _missing(name, package=None):
+        if name == "huggingface_hub":
+            raise ImportError("no module named huggingface_hub")
+        return importlib.import_module(name, package)
+
+    monkeypatch.setattr(pull_mod.importlib, "import_module", _missing)
+
+    with pytest.raises(ImportError) as excinfo:
+        pull_mod.pull_dataset("user/repo", tmp_path / "data")
+
+    assert "synthpix[hf]" in str(excinfo.value)
+
+
+def test_pull_dataset_passes_max_workers(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    fake = _install_fake_hub(monkeypatch)
+
+    pull_mod.pull_dataset(
+        "user/repo", tmp_path / "data", max_workers=2
+    )
+
+    assert fake.calls[-1]["max_workers"] == 2
+
+
+def test_pull_dataset_explicit_ignore_globs(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    fake = _install_fake_hub(monkeypatch)
+
+    pull_mod.pull_dataset(
+        "user/repo",
+        tmp_path / "data",
+        ignore_globs=("**/skip.me",),
+    )
+
+    assert fake.calls[-1]["ignore_patterns"] == ["**/skip.me"]
+
+
+# Sanity check: the helper does not pull huggingface_hub into the module
+# graph eagerly.
+def test_pull_module_does_not_eagerly_import_hub():
+    # When this test runs huggingface_hub may or may not be installed in
+    # the dev venv; either way, the pull module must remain importable
+    # without it. We can only assert the module imports cleanly here.
+    assert isinstance(pull_mod, types.ModuleType)

--- a/tests/hf/test_pull_live.py
+++ b/tests/hf/test_pull_live.py
@@ -1,0 +1,43 @@
+"""Live, network-touching tests for ``synthpix.hf.pull_dataset``.
+
+Skipped by default. To run, set ``HF_TOKEN`` in the environment and pass
+``--run-hf-live`` on the pytest command line, e.g.::
+
+    HF_TOKEN=hf_xxx uv run pytest tests/hf/test_pull_live.py \
+        -m hf_live --run-hf-live
+
+The chosen fixture should be a small, stable, public Hugging Face dataset.
+If you are unsure which dataset to use, leave this test as the placeholder
+skip below and fill in a known-good identifier before flipping the switch.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.mark.hf_live
+def test_pull_dataset_live_roundtrip(tmp_path, request):
+    # Round-trip a small, stable, public dataset. Fill in
+    # ``fixture_repo_id`` with a known-good public HF dataset before
+    # flipping the gate; otherwise this test stays as a deliberate skip so
+    # CI does not pin on a fixture that might be renamed upstream.
+    if not request.config.getoption("--run-hf-live", default=False):
+        pytest.skip("requires --run-hf-live")
+    if not os.environ.get("HF_TOKEN"):
+        pytest.skip("requires HF_TOKEN in env")
+
+    fixture_repo_id: str | None = None
+    if fixture_repo_id is None:
+        pytest.skip(
+            "fill in a known-good public HF dataset before running"
+        )
+
+    from synthpix.hf import pull_dataset
+
+    target = pull_dataset(fixture_repo_id, tmp_path / "data")
+
+    files = [p for p in target.rglob("*") if p.is_file()]
+    assert files, "Expected at least one file to land under local_dir"

--- a/tests/hf/test_pull_live.py
+++ b/tests/hf/test_pull_live.py
@@ -18,6 +18,8 @@ import os
 
 import pytest
 
+# TODO(synthpix#259): swap to a synthpix-owned mirror once one is published
+# so the live smoke test no longer pins on an upstream-owned repo.
 _DEFAULT_LIVE_REPO = "lhoestq/demo1"
 
 

--- a/tests/hf/test_pull_live.py
+++ b/tests/hf/test_pull_live.py
@@ -6,9 +6,10 @@ Skipped by default. To run, set ``HF_TOKEN`` in the environment and pass
     HF_TOKEN=hf_xxx uv run pytest tests/hf/test_pull_live.py \
         -m hf_live --run-hf-live
 
-The chosen fixture should be a small, stable, public Hugging Face dataset.
-If you are unsure which dataset to use, leave this test as the placeholder
-skip below and fill in a known-good identifier before flipping the switch.
+The fixture repo defaults to ``lhoestq/demo1`` — a tiny, stable, public
+demo dataset on the Hub that has been around since 2021. Override with
+``SYNTHPIX_HF_LIVE_REPO=<owner>/<dataset>`` to point at a private synthpix
+mirror or any other dataset of your choice.
 """
 
 from __future__ import annotations
@@ -17,27 +18,19 @@ import os
 
 import pytest
 
+_DEFAULT_LIVE_REPO = "lhoestq/demo1"
+
 
 @pytest.mark.hf_live
-def test_pull_dataset_live_roundtrip(tmp_path, request):
-    # Round-trip a small, stable, public dataset. Fill in
-    # ``fixture_repo_id`` with a known-good public HF dataset before
-    # flipping the gate; otherwise this test stays as a deliberate skip so
-    # CI does not pin on a fixture that might be renamed upstream.
-    if not request.config.getoption("--run-hf-live", default=False):
-        pytest.skip("requires --run-hf-live")
+def test_pull_dataset_live_roundtrip(tmp_path):
     if not os.environ.get("HF_TOKEN"):
         pytest.skip("requires HF_TOKEN in env")
 
-    fixture_repo_id: str | None = None
-    if fixture_repo_id is None:
-        pytest.skip(
-            "fill in a known-good public HF dataset before running"
-        )
+    repo_id = os.environ.get("SYNTHPIX_HF_LIVE_REPO", _DEFAULT_LIVE_REPO)
 
     from synthpix.hf import pull_dataset
 
-    target = pull_dataset(fixture_repo_id, tmp_path / "data")
+    target = pull_dataset(repo_id, tmp_path / "data")
 
     files = [p for p in target.rglob("*") if p.is_file()]
     assert files, "Expected at least one file to land under local_dir"

--- a/tests/hf/test_transfer.py
+++ b/tests/hf/test_transfer.py
@@ -1,0 +1,56 @@
+"""Tests for ``synthpix.hf._transfer`` env-var toggling."""
+
+from __future__ import annotations
+
+import os
+
+from synthpix.hf import _transfer
+
+
+_FLAG = "HF_HUB_ENABLE_HF_TRANSFER"
+
+
+def test_enable_hf_transfer_sets_env_when_available(monkeypatch):
+    monkeypatch.delenv(_FLAG, raising=False)
+    monkeypatch.setattr(
+        _transfer, "_hf_transfer_available", lambda: True
+    )
+
+    assert _FLAG not in os.environ
+    with _transfer.enable_hf_transfer():
+        assert os.environ[_FLAG] == "1"
+    assert _FLAG not in os.environ
+
+
+def test_enable_hf_transfer_no_op_when_missing(monkeypatch):
+    monkeypatch.delenv(_FLAG, raising=False)
+    monkeypatch.setattr(
+        _transfer, "_hf_transfer_available", lambda: False
+    )
+
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        _transfer.logger,
+        "warning",
+        lambda msg, *a, **kw: warnings.append(msg),
+    )
+
+    with _transfer.enable_hf_transfer():
+        # Env var must not be set when the library is unavailable.
+        assert _FLAG not in os.environ
+
+    assert _FLAG not in os.environ
+    assert warnings, "Expected a warning when hf_transfer is missing"
+    assert "hf_transfer" in warnings[0]
+
+
+def test_enable_hf_transfer_restores_existing_value(monkeypatch):
+    monkeypatch.setenv(_FLAG, "0")
+    monkeypatch.setattr(
+        _transfer, "_hf_transfer_available", lambda: True
+    )
+
+    with _transfer.enable_hf_transfer():
+        assert os.environ[_FLAG] == "1"
+
+    assert os.environ[_FLAG] == "0"

--- a/tests/hf/test_transfer.py
+++ b/tests/hf/test_transfer.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import threading
+import time
 
 from synthpix.hf import _transfer
 
@@ -12,9 +14,7 @@ _FLAG = "HF_HUB_ENABLE_HF_TRANSFER"
 
 def test_enable_hf_transfer_sets_env_when_available(monkeypatch):
     monkeypatch.delenv(_FLAG, raising=False)
-    monkeypatch.setattr(
-        _transfer, "_hf_transfer_available", lambda: True
-    )
+    monkeypatch.setattr(_transfer, "_hf_transfer_available", lambda: True)
 
     assert _FLAG not in os.environ
     with _transfer.enable_hf_transfer():
@@ -24,9 +24,7 @@ def test_enable_hf_transfer_sets_env_when_available(monkeypatch):
 
 def test_enable_hf_transfer_no_op_when_missing(monkeypatch):
     monkeypatch.delenv(_FLAG, raising=False)
-    monkeypatch.setattr(
-        _transfer, "_hf_transfer_available", lambda: False
-    )
+    monkeypatch.setattr(_transfer, "_hf_transfer_available", lambda: False)
 
     warnings: list[str] = []
     monkeypatch.setattr(
@@ -46,11 +44,64 @@ def test_enable_hf_transfer_no_op_when_missing(monkeypatch):
 
 def test_enable_hf_transfer_restores_existing_value(monkeypatch):
     monkeypatch.setenv(_FLAG, "0")
-    monkeypatch.setattr(
-        _transfer, "_hf_transfer_available", lambda: True
-    )
+    monkeypatch.setattr(_transfer, "_hf_transfer_available", lambda: True)
 
     with _transfer.enable_hf_transfer():
         assert os.environ[_FLAG] == "1"
 
     assert os.environ[_FLAG] == "0"
+
+
+def test_no_op_branch_clears_stale_flag(monkeypatch):
+    # If ``hf_transfer`` is missing but the environment still carries a
+    # stale ``HF_HUB_ENABLE_HF_TRANSFER=1``, ``huggingface_hub`` will try
+    # the accelerated path and fail. The context manager must clear it for
+    # the duration of the block and restore it afterwards.
+    monkeypatch.setenv(_FLAG, "1")
+    monkeypatch.setattr(_transfer, "_hf_transfer_available", lambda: False)
+    monkeypatch.setattr(
+        _transfer.logger, "warning", lambda *a, **kw: None
+    )
+
+    with _transfer.enable_hf_transfer():
+        assert _FLAG not in os.environ
+
+    assert os.environ[_FLAG] == "1"
+
+
+def test_nested_enable_is_reentrant(monkeypatch):
+    # Nested calls must not let an inner exit pop the flag while an outer
+    # context still expects it to be set.
+    monkeypatch.delenv(_FLAG, raising=False)
+    monkeypatch.setattr(_transfer, "_hf_transfer_available", lambda: True)
+
+    with _transfer.enable_hf_transfer():
+        assert os.environ[_FLAG] == "1"
+        with _transfer.enable_hf_transfer():
+            assert os.environ[_FLAG] == "1"
+        # Inner exit must not pop the flag while the outer is still active.
+        assert os.environ[_FLAG] == "1"
+    assert _FLAG not in os.environ
+
+
+def test_overlapping_threads_do_not_leak_flag(monkeypatch):
+    # Two threads entering and leaving overlapping contexts must not leak
+    # the flag or restore it in the wrong order.
+    monkeypatch.delenv(_FLAG, raising=False)
+    monkeypatch.setattr(_transfer, "_hf_transfer_available", lambda: True)
+
+    barrier = threading.Barrier(2)
+
+    def worker():
+        barrier.wait()
+        with _transfer.enable_hf_transfer():
+            time.sleep(0.01)
+            assert os.environ[_FLAG] == "1"
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert _FLAG not in os.environ


### PR DESCRIPTION
> **Stacked on PR #258** (`feat/huggingface-integration`). When that lands on `dev`, this PR's base will auto-update.

## Summary

PR2 of the planned 5 for Hugging Face Hub integration. Adds the **download side** — `pull_dataset()` and the `synthpix-hf pull` CLI subcommand — built on top of PR1's `auth.py` + `cli.py` scaffolding.

This is the first network-touching PR in the series; pull-only first because it's the safer operation (no risk of accidental public uploads, and the live test can target an existing public dataset rather than creating one).

### What this PR adds

| New module | Purpose |
|---|---|
| `src/synthpix/hf/_transfer.py` | `enable_hf_transfer()` context manager — toggles `HF_HUB_ENABLE_HF_TRANSFER=1` around a block, restores prior value on exit. Lazy `find_spec` probe; no-op + warning if `hf_transfer` isn't installed. |
| `src/synthpix/hf/pull.py` | `pull_dataset(repo_id, local_dir, *, revision, token, splits, include_globs, ignore_globs, max_workers) -> Path`. Wraps `snapshot_download` with the synthpix conventions: layout-preserving (no symlinks), splits-as-filter convenience, transfer acceleration, idempotent/resumable. |

### Files edited

- `src/synthpix/hf/cli.py` — `synthpix-hf pull` is no longer stubbed; supports `--splits train,val`, repeated `--include`/`--ignore`, `--revision`, `--token`, `--max-workers`. On success prints a one-line summary using `inspect_local_layout` (falls back to `os.walk` when the tree doesn't match `train/val/test/tune/`).
- `src/synthpix/hf/__init__.py` — re-exports `pull_dataset`.
- `tests/conftest.py` — adds `--run-hf-live` pytest option.
- `pyproject.toml` — registers the `hf_live` pytest marker.

### Tests

- `tests/hf/test_transfer.py` — env var set/restore behavior, no-op when `hf_transfer` missing, restoration of pre-existing value
- `tests/hf/test_pull.py` — 8 mocked tests covering: basic call shape, splits→`allow_patterns` synthesis, explicit `include_globs` overriding `splits` (with warning), token pass-through, token resolution from env, return value, file-as-local-dir error, missing-`huggingface_hub` `ImportError` message
- `tests/hf/test_cli.py` — extended with 4 tests for `pull` subcommand (invocation, multi-`--include`, non-zero on runtime error, token-never-logged); pre-existing `push` stub test left in place
- `tests/hf/test_pull_live.py` — gated by `@pytest.mark.hf_live` AND `--run-hf-live`. Currently a parameterized skip placeholder since the agent didn't want to bake in a specific HF fixture name that might rename upstream. PR4 should pick a stable target dataset and fill it in.

**Local result:** `uv run pytest tests/hf/ -q` → **43 passed, 1 skipped, 1 failed**. The 1 failure is a pre-existing PR1 bug (see below).

## Known issue — pre-existing PR1 bug surfaced

The test `tests/hf/test_auth.py::test_resolve_token_falls_back_to_cached` fails on current `huggingface_hub` (v1.x) because **`HfFolder.get_token()` was removed**. PR1's `auth._cached_token()` still calls it.

**Fix is ~3 lines**, will be folded into PR1's review-response commit when Copilot's review on #258 lands. After PR1 is updated, this branch will be rebased on top and the failure will clear.

The same release also dropped `local_dir_use_symlinks` from `snapshot_download` — PR2 already accounts for this by omitting the kwarg (new default already gives the desired no-symlink behavior when `local_dir` is set).

## What this PR explicitly does **not** include

- `push_dataset` + safety gates (PR3)
- `hf://` URI resolver in `data_sources/` (PR5, stretch)
- Docs (PR4)
- Any changes to `scripts/download_piv_*.py`

## Test plan

- [x] Local: `uv run pytest tests/hf/ -q` — 43 passed (1 pre-existing failure traced to PR1)
- [x] Local: `uv run pre-commit run --files <touched>` + `--hook-stage push` — clean
- [ ] CI on stacked base
- [ ] Once PR1 lands the auth fix, rebase and rerun; 1 failure should clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)