### PR TITLE
feat(hf): PR3/5 — push_dataset with default-private safety gate + --push-to flag on download scripts

### DIFF
--- a/scripts/download_piv_1.py
+++ b/scripts/download_piv_1.py
@@ -3,6 +3,12 @@
 This script provides a full end-to-end pipeline for preparing the
 PIV Dataset (Class 1) from the public Google Drive repositories.
 
+Optional flags ``--push-to``, ``--push-private`` (default),
+``--push-public``, ``--allow-public``, ``--push-token``, and
+``--no-push-card`` push the resulting tree to a Hugging Face Hub dataset
+repo via :func:`synthpix.hf.push_dataset` when ``--push-to`` is set.
+Public pushes require the explicit ``--allow-public`` safety gate.
+
 ==============================================================
  PIV Dataset Class 1 Builder
 ==============================================================
@@ -448,6 +454,75 @@ def perform_split(packed_root: Path, split_root: Path) -> None:
     print(f"Split datasets saved under: {split_root}")
 
 
+_PUSH_SOURCE_URL = "https://github.com/shengzesnail/PIV_dataset"
+_PUSH_CITATION = (
+    "Cai, S., Zhou, S., Xu, C., Gao, Q. (2019). "
+    "Dense motion estimation of particle images via a convolutional "
+    "neural network. Exp Fluids 60, 73.\n\n"
+    "@article{cai2019dense,\n"
+    "  title={Dense motion estimation of particle images via "
+    "a convolutional neural network},\n"
+    "  author={Cai, Shengze and Zhou, Shichao and Xu, Chuanqi "
+    "and Gao, Qi},\n"
+    "  journal={Experiments in Fluids},\n"
+    "  volume={60},\n"
+    "  number={4},\n"
+    "  pages={73},\n"
+    "  year={2019},\n"
+    "  publisher={Springer}\n"
+    "}"
+)
+
+
+def _default_card_meta(repo_id: str) -> "object":
+    """Return a default ``DatasetCardMeta`` for the class-1 dataset.
+
+    The import is deferred so the rest of this script keeps working
+    without the ``[hf]`` extra installed.
+
+    Args:
+        repo_id: ``<owner>/<name>`` identifier on the Hub; the trailing
+            name becomes the card's ``name`` field.
+
+    Returns:
+        DatasetCardMeta: A populated card metadata object.
+    """
+    from synthpix.hf import DatasetCardMeta  # noqa: PLC0415
+
+    name = repo_id.split("/", 1)[-1]
+    return DatasetCardMeta(
+        name=name,
+        source_url=_PUSH_SOURCE_URL,
+        citation=_PUSH_CITATION,
+        pretty_name=name,
+        tags=("PIV", "synthetic", "optical-flow", "class-1"),
+    )
+
+
+def _maybe_push(args: argparse.Namespace, out_dir_path: Path) -> None:
+    """Optionally push ``out_dir_path`` to the Hub based on CLI flags.
+
+    Args:
+        args: Parsed CLI namespace; ``args.push_to`` controls activation.
+        out_dir_path: Local directory uploaded to the Hub.
+    """
+    if not getattr(args, "push_to", None):
+        return
+
+    from synthpix.hf import push_dataset  # noqa: PLC0415
+
+    card_meta = None if args.no_push_card else _default_card_meta(args.push_to)
+    sha = push_dataset(
+        local_dir=out_dir_path,
+        repo_id=args.push_to,
+        private=not args.push_public,
+        allow_public=args.allow_public,
+        token=args.push_token,
+        card_meta=card_meta,
+    )
+    print(sha)
+
+
 def main(out_dir: str, target_shape: str) -> None:
     """Main function to orchestrate the dataset preparation workflow.
 
@@ -516,18 +591,70 @@ if __name__ == "__main__":
         default="256x256",
         help="Target shape (HxW) for resizing images and flow, e.g., '256x256'",
     )
+    parser.add_argument(
+        "--push-to",
+        type=str,
+        default=None,
+        help=(
+            "Optional Hugging Face Hub dataset repo id "
+            "(<owner>/<name>) to push the built dataset to."
+        ),
+    )
+    parser.add_argument(
+        "--push-private",
+        action="store_true",
+        default=True,
+        help="Push as a private repo (default).",
+    )
+    parser.add_argument(
+        "--push-public",
+        action="store_true",
+        default=False,
+        help=(
+            "Push as a public repo. Requires --allow-public. "
+            "Class-1 sources are research-only; do not redistribute "
+            "publicly without explicit permission."
+        ),
+    )
+    parser.add_argument(
+        "--allow-public",
+        action="store_true",
+        default=False,
+        help="Safety gate companion for --push-public.",
+    )
+    parser.add_argument(
+        "--push-token",
+        type=str,
+        default=None,
+        help="Explicit HF token; falls back to HF_TOKEN/cache.",
+    )
+    parser.add_argument(
+        "--no-push-card",
+        action="store_true",
+        default=False,
+        help="Skip dataset-card generation on push.",
+    )
     args = parser.parse_args()
+
+    if args.push_public and not args.allow_public:
+        print(
+            "--push-public requires --allow-public (safety gate).",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
     try:
         split_ratios = list(map(int, args.split_ratio.split("/")))
         if len(split_ratios) != 3 or sum(split_ratios) != 100:
             raise ValueError
-        out_path_split = Path(args.out_dir) / "splits"
-        fetch_splits(out_path_split, args.split_seed, split_ratios)
-        main(args.out_dir, args.target_shape)
     except Exception as e:
         print(
             f"Split ratio is in the wrong format: {args.split_ratio}. "
             f"Use '80/10/10' format summing to 100. Error: {e}"
         )
         sys.exit(1)
+
+    out_path_split = Path(args.out_dir) / "splits"
+    fetch_splits(out_path_split, args.split_seed, split_ratios)
+    main(args.out_dir, args.target_shape)
+    _maybe_push(args, Path(args.out_dir))

--- a/scripts/download_piv_1.py
+++ b/scripts/download_piv_1.py
@@ -3,11 +3,11 @@
 This script provides a full end-to-end pipeline for preparing the
 PIV Dataset (Class 1) from the public Google Drive repositories.
 
-Optional flags ``--push-to``, ``--push-private`` (default),
-``--push-public``, ``--allow-public``, ``--push-token``, and
-``--no-push-card`` push the resulting tree to a Hugging Face Hub dataset
-repo via :func:`synthpix.hf.push_dataset` when ``--push-to`` is set.
-Public pushes require the explicit ``--allow-public`` safety gate.
+Optional flags ``--push-to``, ``--push-public``, ``--allow-public``,
+``--push-token``, and ``--no-push-card`` push the resulting tree to a
+Hugging Face Hub dataset repo via :func:`synthpix.hf.push_dataset` when
+``--push-to`` is set. The push defaults to private; public pushes
+require the explicit ``--allow-public`` safety gate.
 
 ==============================================================
  PIV Dataset Class 1 Builder
@@ -601,19 +601,13 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
-        "--push-private",
-        action="store_true",
-        default=True,
-        help="Push as a private repo (default).",
-    )
-    parser.add_argument(
         "--push-public",
         action="store_true",
         default=False,
         help=(
-            "Push as a public repo. Requires --allow-public. "
-            "Class-1 sources are research-only; do not redistribute "
-            "publicly without explicit permission."
+            "Push as a public repo (private by default). Requires "
+            "--allow-public. Class-1 sources are research-only; do not "
+            "redistribute publicly without explicit permission."
         ),
     )
     parser.add_argument(

--- a/scripts/download_piv_2.py
+++ b/scripts/download_piv_2.py
@@ -1,7 +1,7 @@
 """Download and process the PIV class 2 dataset from Zenodo.
 
-Optional flags ``--push-to``, ``--push-private`` (default),
-``--push-public``, ``--allow-public``, ``--push-token``, and
+Optional flags ``--push-to``, ``--push-public``,
+``--allow-public``, ``--push-token``, and
 ``--no-push-card`` push the resulting tree to a Hugging Face Hub dataset
 repo via :func:`synthpix.hf.push_dataset` when ``--push-to`` is set.
 Public pushes require the explicit ``--allow-public`` safety gate.
@@ -263,19 +263,13 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
-        "--push-private",
-        action="store_true",
-        default=True,
-        help="Push as a private repo (default).",
-    )
-    parser.add_argument(
         "--push-public",
         action="store_true",
         default=False,
         help=(
-            "Push as a public repo. Requires --allow-public. "
-            "Class-2 sources are research-only; do not redistribute "
-            "publicly without explicit permission."
+            "Push as a public repo (private by default). Requires "
+            "--allow-public. Class-2 sources are research-only; do not "
+            "redistribute publicly without explicit permission."
         ),
     )
     parser.add_argument(

--- a/scripts/download_piv_2.py
+++ b/scripts/download_piv_2.py
@@ -1,6 +1,14 @@
-"""Download and process the PIV class 2 dataset from Zenodo."""
+"""Download and process the PIV class 2 dataset from Zenodo.
+
+Optional flags ``--push-to``, ``--push-private`` (default),
+``--push-public``, ``--allow-public``, ``--push-token``, and
+``--no-push-card`` push the resulting tree to a Hugging Face Hub dataset
+repo via :func:`synthpix.hf.push_dataset` when ``--push-to`` is set.
+Public pushes require the explicit ``--allow-public`` safety gate.
+"""
 
 import argparse
+import sys
 import zipfile
 from pathlib import Path
 
@@ -174,8 +182,128 @@ def main(out_dir: str) -> None:
         process_tfrecord(tfr, subdir)
 
 
+_PUSH_SOURCE_URL = "https://github.com/shengzesnail/PIV_dataset"
+_PUSH_CITATION = (
+    "Cai, S., Zhou, S., Xu, C., Gao, Q. (2019). "
+    "Dense motion estimation of particle images via a convolutional "
+    "neural network. Exp Fluids 60, 73.\n\n"
+    "@article{cai2019dense,\n"
+    "  title={Dense motion estimation of particle images via "
+    "a convolutional neural network},\n"
+    "  author={Cai, Shengze and Zhou, Shichao and Xu, Chuanqi "
+    "and Gao, Qi},\n"
+    "  journal={Experiments in Fluids},\n"
+    "  volume={60},\n"
+    "  number={4},\n"
+    "  pages={73},\n"
+    "  year={2019},\n"
+    "  publisher={Springer}\n"
+    "}"
+)
+
+
+def _default_card_meta(repo_id: str) -> "object":
+    """Return a default ``DatasetCardMeta`` for the class-2 dataset.
+
+    The import is deferred so the rest of this script keeps working
+    without the ``[hf]`` extra installed.
+
+    Args:
+        repo_id: ``<owner>/<name>`` identifier on the Hub.
+
+    Returns:
+        DatasetCardMeta: A populated card metadata object.
+    """
+    from synthpix.hf import DatasetCardMeta  # noqa: PLC0415
+
+    name = repo_id.split("/", 1)[-1]
+    return DatasetCardMeta(
+        name=name,
+        source_url=_PUSH_SOURCE_URL,
+        citation=_PUSH_CITATION,
+        pretty_name=name,
+        tags=("PIV", "synthetic", "optical-flow", "class-2"),
+    )
+
+
+def _maybe_push(args: argparse.Namespace, out_dir_path: Path) -> None:
+    """Optionally push ``out_dir_path`` to the Hub based on CLI flags.
+
+    Args:
+        args: Parsed CLI namespace; ``args.push_to`` controls activation.
+        out_dir_path: Local directory uploaded to the Hub.
+    """
+    if not getattr(args, "push_to", None):
+        return
+
+    from synthpix.hf import push_dataset  # noqa: PLC0415
+
+    card_meta = None if args.no_push_card else _default_card_meta(args.push_to)
+    sha = push_dataset(
+        local_dir=out_dir_path,
+        repo_id=args.push_to,
+        private=not args.push_public,
+        allow_public=args.allow_public,
+        token=args.push_token,
+        card_meta=card_meta,
+    )
+    print(sha)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--out-dir", required=True)
+    parser.add_argument(
+        "--push-to",
+        type=str,
+        default=None,
+        help=(
+            "Optional Hugging Face Hub dataset repo id "
+            "(<owner>/<name>) to push the built dataset to."
+        ),
+    )
+    parser.add_argument(
+        "--push-private",
+        action="store_true",
+        default=True,
+        help="Push as a private repo (default).",
+    )
+    parser.add_argument(
+        "--push-public",
+        action="store_true",
+        default=False,
+        help=(
+            "Push as a public repo. Requires --allow-public. "
+            "Class-2 sources are research-only; do not redistribute "
+            "publicly without explicit permission."
+        ),
+    )
+    parser.add_argument(
+        "--allow-public",
+        action="store_true",
+        default=False,
+        help="Safety gate companion for --push-public.",
+    )
+    parser.add_argument(
+        "--push-token",
+        type=str,
+        default=None,
+        help="Explicit HF token; falls back to HF_TOKEN/cache.",
+    )
+    parser.add_argument(
+        "--no-push-card",
+        action="store_true",
+        default=False,
+        help="Skip dataset-card generation on push.",
+    )
     args = parser.parse_args()
+
+    if args.push_public and not args.allow_public:
+        print(
+            "--push-public requires --allow-public (safety gate).",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
     main(args.out_dir)
+    _maybe_push(args, Path(args.out_dir))

--- a/src/synthpix/hf/__init__.py
+++ b/src/synthpix/hf/__init__.py
@@ -1,15 +1,17 @@
 """Hugging Face Hub integration for the ``synthpix`` package.
 
 This subpackage exposes metadata helpers, layout introspection, and the
-``pull_dataset`` downloader. ``huggingface_hub`` is imported lazily inside
-:mod:`synthpix.hf.auth` and :mod:`synthpix.hf.pull`, so this module remains
-usable without the ``[hf]`` optional extra installed.
+``pull_dataset`` / ``push_dataset`` transports. ``huggingface_hub`` is
+imported lazily inside :mod:`synthpix.hf.auth`, :mod:`synthpix.hf.pull`,
+and :mod:`synthpix.hf.push`, so this module remains usable without the
+``[hf]`` optional extra installed.
 """
 
 from synthpix.hf.auth import resolve_token
 from synthpix.hf.card import DatasetCardMeta, make_dataset_card
 from synthpix.hf.layout import LayoutSummary, inspect_local_layout
 from synthpix.hf.pull import pull_dataset
+from synthpix.hf.push import push_dataset
 
 __all__ = [
     "DatasetCardMeta",
@@ -17,5 +19,6 @@ __all__ = [
     "inspect_local_layout",
     "make_dataset_card",
     "pull_dataset",
+    "push_dataset",
     "resolve_token",
 ]

--- a/src/synthpix/hf/cli.py
+++ b/src/synthpix/hf/cli.py
@@ -10,14 +10,10 @@ from pathlib import Path
 from synthpix.hf.card import DatasetCardMeta, make_dataset_card
 from synthpix.hf.layout import inspect_local_layout
 from synthpix.hf.pull import pull_dataset
+from synthpix.hf.push import push_dataset
 from synthpix.utils import SYNTHPIX_SCOPE, get_logger
 
 logger = get_logger(__name__, scope=SYNTHPIX_SCOPE)
-
-_NOT_IMPLEMENTED = (
-    "This subcommand is not yet implemented. "
-    "Stay tuned for the upcoming push rollout."
-)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -49,9 +45,53 @@ def _build_parser() -> argparse.ArgumentParser:
     card.add_argument("--output", type=Path, default=None)
     card.add_argument("--force", action="store_true")
 
-    push = sub.add_parser("push", help="(PR3) Push a dataset to the Hub.")
-    push.add_argument("local_dir", nargs="?", default=None)
-    push.add_argument("--repo-id", default=None)
+    push = sub.add_parser("push", help="Push a dataset to the Hub.")
+    push.add_argument("local_dir", type=Path)
+    push.add_argument("repo_id")
+    push.add_argument(
+        "--public",
+        action="store_true",
+        help="Create/keep the repo as public. Requires --allow-public.",
+    )
+    push.add_argument(
+        "--allow-public",
+        action="store_true",
+        help=(
+            "Safety gate companion for --public; explicit acknowledgment "
+            "that public redistribution is permitted for this dataset."
+        ),
+    )
+    push.add_argument("--token", default=None)
+    push.add_argument("--revision", default="main")
+    push.add_argument("--commit-message", default=None)
+    push.add_argument(
+        "--no-card",
+        action="store_true",
+        help="Skip dataset-card generation even if card flags are set.",
+    )
+    push.add_argument("--card-name", default=None)
+    push.add_argument("--card-source-url", default=None)
+    push.add_argument(
+        "--card-citation",
+        default=None,
+        help="Citation text, or path to a file containing the citation.",
+    )
+    push.add_argument(
+        "--include",
+        action="append",
+        default=None,
+        metavar="PATTERN",
+        help="Allow-list glob; may be repeated. Overrides the default set.",
+    )
+    push.add_argument(
+        "--ignore",
+        action="append",
+        default=None,
+        metavar="PATTERN",
+        help="Deny-list glob; may be repeated. Overrides the default set.",
+    )
+    push.add_argument("--max-workers", type=int, default=8)
+    push.add_argument("--dry-run", action="store_true")
 
     pull = sub.add_parser("pull", help="Pull a dataset from the Hub.")
     pull.add_argument("repo_id")
@@ -218,9 +258,87 @@ def _run_pull(args: argparse.Namespace) -> int:
     return 0
 
 
-def _run_stub(name: str) -> int:
-    print(f"`synthpix-hf {name}`: {_NOT_IMPLEMENTED}", file=sys.stderr)
-    return 2
+def _build_push_card_meta(args: argparse.Namespace) -> DatasetCardMeta | None:
+    # The CLI builds card metadata only when both the source URL and the
+    # citation are provided. Partial flag sets are surfaced as a parse error
+    # by the caller before reaching this helper.
+    if args.no_card:
+        return None
+    if args.card_source_url is None and args.card_citation is None:
+        return None
+    citation = _read_citation(args.card_citation)
+    name = args.card_name or args.repo_id.split("/", 1)[-1]
+    return DatasetCardMeta(
+        name=name,
+        source_url=args.card_source_url,
+        citation=citation,
+        pretty_name=args.card_name,
+    )
+
+
+def _confirm_public_on_tty() -> bool:
+    # ``--allow-public`` is the deliberate friction. On a TTY we additionally
+    # require the user to type ``yes`` so that copy/pasted commands don't
+    # silently flip a private dataset to public. Pipelines (non-TTY) are
+    # trusted to mean what they say.
+    if not sys.stdin.isatty():
+        return True
+    try:
+        answer = input("Refusing to push public unless you type 'yes': ")
+    except EOFError:
+        return False
+    return answer.strip() == "yes"
+
+
+def _run_push(args: argparse.Namespace) -> int:
+    if args.public and not args.allow_public:
+        print(
+            "--public requires --allow-public (this is a safety gate; "
+            "see push_dataset docstring)",
+            file=sys.stderr,
+        )
+        return 2
+
+    card_partial = (args.card_source_url is None) ^ (args.card_citation is None)
+    if card_partial and not args.no_card:
+        print(
+            "--card-source-url and --card-citation must be provided "
+            "together; pass --no-card to skip card generation.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.public and not _confirm_public_on_tty():
+        print("Aborted: public push not confirmed.", file=sys.stderr)
+        return 1
+
+    card_meta = _build_push_card_meta(args)
+    kwargs: dict = {
+        "private": not args.public,
+        "allow_public": args.allow_public,
+        "token": args.token,
+        "revision": args.revision,
+        "commit_message": args.commit_message,
+        "card_meta": card_meta,
+        "max_workers": args.max_workers,
+        "dry_run": args.dry_run,
+    }
+    if args.include is not None:
+        kwargs["include_globs"] = tuple(args.include)
+    if args.ignore is not None:
+        kwargs["ignore_globs"] = tuple(args.ignore)
+
+    try:
+        sha = push_dataset(args.local_dir, args.repo_id, **kwargs)
+    except Exception as exc:
+        print(f"synthpix-hf push: {exc}", file=sys.stderr)
+        return 1
+
+    if args.dry_run:
+        print(f"DRY RUN: would push {args.local_dir} to {args.repo_id}")
+    else:
+        print(f"Pushed {args.repo_id}@{sha}")
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -240,7 +358,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "pull":
         return _run_pull(args)
     if args.command == "push":
-        return _run_stub(args.command)
+        return _run_push(args)
 
     # ``add_subparsers(required=True)`` makes this unreachable; ``parser.error``
     # exits in any case but mypy/basedpyright need a concrete return.

--- a/src/synthpix/hf/cli.py
+++ b/src/synthpix/hf/cli.py
@@ -91,6 +91,16 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Deny-list glob; may be repeated. Overrides the default set.",
     )
     push.add_argument("--max-workers", type=int, default=8)
+    push.add_argument(
+        "--large-folder",
+        choices=("auto", "yes", "no"),
+        default="auto",
+        help=(
+            "Upload transport: 'auto' (default) routes large trees "
+            "through upload_large_folder (resumable, batched commits); "
+            "'yes'/'no' force it on/off."
+        ),
+    )
     push.add_argument("--dry-run", action="store_true")
 
     pull = sub.add_parser("pull", help="Pull a dataset from the Hub.")
@@ -321,6 +331,9 @@ def _run_push(args: argparse.Namespace) -> int:
         "commit_message": args.commit_message,
         "card_meta": card_meta,
         "max_workers": args.max_workers,
+        "large_folder": {"auto": None, "yes": True, "no": False}[
+            args.large_folder
+        ],
         "dry_run": args.dry_run,
     }
     if args.include is not None:

--- a/src/synthpix/hf/push.py
+++ b/src/synthpix/hf/push.py
@@ -1,0 +1,325 @@
+"""Upload synthpix-hosted PIV datasets to the Hugging Face Hub.
+
+The public entry point is :func:`push_dataset`. It wraps
+``huggingface_hub.HfApi.upload_folder`` with a small set of guarantees
+beyond the upstream call:
+
+* a default-private safety gate (``allow_public`` must be explicitly
+  set before a public repo is created);
+* lazy import of ``huggingface_hub`` so the package keeps working
+  without the ``[hf]`` extra installed;
+* token resolution via :func:`synthpix.hf.auth.resolve_token`;
+* optional dataset-card generation right before the upload;
+* ``hf_transfer`` acceleration when available via
+  :func:`synthpix.hf._transfer.enable_hf_transfer`;
+* a ``dry_run`` mode that compares the local file set against the
+  files already in the remote repo.
+
+Tokens are never logged.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+from fnmatch import fnmatchcase
+from pathlib import Path
+
+from synthpix.hf._transfer import enable_hf_transfer
+from synthpix.hf.auth import resolve_token
+from synthpix.hf.card import DatasetCardMeta, make_dataset_card
+from synthpix.hf.layout import inspect_local_layout
+from synthpix.utils import SYNTHPIX_SCOPE, get_logger
+
+logger = get_logger(__name__, scope=SYNTHPIX_SCOPE)
+
+_DEFAULT_INCLUDE: tuple[str, ...] = (
+    "train/**",
+    "val/**",
+    "test/**",
+    "tune/**",
+    "splits/**",
+    "README.md",
+)
+_DEFAULT_IGNORE: tuple[str, ...] = (
+    "raw_*/**",
+    "packed_*/**",
+    "**/.DS_Store",
+    "**/__pycache__/**",
+    "**/.git/**",
+)
+
+_REPO_ID_RE = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$"
+)
+
+_PUBLIC_GATE_MESSAGE = (
+    "Refusing to create a public HF Hub dataset without --allow-public. "
+    "The PIV class-1 source is research-only / all rights reserved; "
+    "redistribution under a public license is not permitted by default. "
+    "Pass allow_public=True (CLI: --allow-public) to override."
+)
+
+
+def _validate_local_dir(local_dir: Path) -> None:
+    if not local_dir.exists():
+        raise ValueError(f"local_dir does not exist: {local_dir}")
+    if not local_dir.is_dir():
+        raise ValueError(f"local_dir is not a directory: {local_dir}")
+
+
+def _validate_repo_id(repo_id: str) -> None:
+    if not _REPO_ID_RE.match(repo_id):
+        raise ValueError(
+            f"repo_id must look like 'owner/name', got: {repo_id!r}"
+        )
+
+
+def _maybe_write_card(local_dir: Path, card_meta: DatasetCardMeta) -> None:
+    layout = inspect_local_layout(local_dir)
+    rendered = make_dataset_card(card_meta, layout)
+    readme_path = local_dir / "README.md"
+    if readme_path.exists():
+        try:
+            existing = readme_path.read_text()
+        except OSError:
+            existing = None
+        if existing is not None and existing != rendered:
+            logger.warning("overwriting existing README.md")
+    readme_path.write_text(rendered)
+
+
+def _iter_relative_files(local_dir: Path) -> list[str]:
+    """Return repo-relative POSIX paths for every regular file under root.
+
+    Args:
+        local_dir: Directory whose tree is walked.
+
+    Returns:
+        list[str]: Repo-relative POSIX paths for every regular file.
+    """
+    files: list[str] = []
+    for entry in local_dir.rglob("*"):
+        if entry.is_file():
+            files.append(entry.relative_to(local_dir).as_posix())
+    return files
+
+
+def _matches_any(rel_path: str, patterns: tuple[str, ...]) -> bool:
+    for pattern in patterns:
+        # Normalize ``**`` to ``*`` for ``fnmatch`` so directory-globs match.
+        # ``fnmatch`` does not understand ``**`` natively; for our purposes
+        # ``train/**`` should match ``train/anything/deep/file.mat``.
+        if fnmatchcase(rel_path, pattern):
+            return True
+        # Translate ``a/**`` -> match anything below ``a/``.
+        if "**" in pattern:
+            translated = pattern.replace("/**", "/*").replace("**", "*")
+            if fnmatchcase(rel_path, translated):
+                return True
+            # Also match arbitrary nesting: turn ``a/**`` into prefix match.
+            prefix = pattern.split("/**", 1)[0]
+            if pattern.endswith("/**") and (
+                rel_path == prefix or rel_path.startswith(prefix + "/")
+            ):
+                return True
+    return False
+
+
+def _filter_local_files(
+    local_dir: Path,
+    include_globs: tuple[str, ...],
+    ignore_globs: tuple[str, ...],
+) -> list[str]:
+    selected: list[str] = []
+    for rel in _iter_relative_files(local_dir):
+        if not _matches_any(rel, include_globs):
+            continue
+        if _matches_any(rel, ignore_globs):
+            continue
+        selected.append(rel)
+    return sorted(selected)
+
+
+def _dry_run_summary(
+    local_dir: Path,
+    repo_id: str,
+    revision: str,
+    include_globs: tuple[str, ...],
+    ignore_globs: tuple[str, ...],
+    token: str | None,
+) -> str:
+    """Print a per-file dry-run plan; return ``"dry-run"`` for the caller.
+
+    Args:
+        local_dir: Local directory used for the diff.
+        repo_id: Remote ``<owner>/<name>`` identifier.
+        revision: Git-style revision queried on the Hub.
+        include_globs: ``allow_patterns`` for the diff.
+        ignore_globs: ``ignore_patterns`` for the diff.
+        token: Resolved Hugging Face token, if any.
+
+    Returns:
+        str: The literal ``"dry-run"`` sentinel.
+
+    Raises:
+        ImportError: If ``huggingface_hub`` is not installed.
+    """
+    try:
+        hub = importlib.import_module("huggingface_hub")
+    except ImportError as exc:
+        raise ImportError(
+            "huggingface_hub is required for synthpix.hf.push_dataset; "
+            "install with `pip install synthpix[hf]`"
+        ) from exc
+
+    try:
+        errors_mod = importlib.import_module("huggingface_hub.errors")
+        repo_not_found = errors_mod.RepositoryNotFoundError
+    except (ImportError, AttributeError):
+        try:
+            utils_mod = importlib.import_module("huggingface_hub.utils")
+            repo_not_found = utils_mod.RepositoryNotFoundError
+        except (ImportError, AttributeError):
+            repo_not_found = Exception  # type: ignore[assignment]
+
+    api = hub.HfApi(token=token)
+    try:
+        remote_files = api.list_repo_files(
+            repo_id, repo_type="dataset", revision=revision
+        )
+    except repo_not_found:
+        remote_files = []
+    remote_set = set(remote_files)
+
+    local_files = _filter_local_files(local_dir, include_globs, ignore_globs)
+    new = [f for f in local_files if f not in remote_set]
+    unchanged = [f for f in local_files if f in remote_set]
+
+    print(f"DRY RUN: {repo_id}@{revision}")
+    print(f"  local_dir: {local_dir}")
+    print(f"  new files: {len(new)}")
+    for f in new:
+        print(f"    + {f}")
+    print(f"  unchanged files: {len(unchanged)}")
+    for f in unchanged:
+        print(f"    = {f}")
+    return "dry-run"
+
+
+def push_dataset(
+    local_dir: str | Path,
+    repo_id: str,
+    *,
+    private: bool = True,
+    allow_public: bool = False,
+    token: str | None = None,
+    revision: str = "main",
+    commit_message: str | None = None,
+    card_meta: DatasetCardMeta | None = None,
+    include_globs: tuple[str, ...] = _DEFAULT_INCLUDE,
+    ignore_globs: tuple[str, ...] = _DEFAULT_IGNORE,
+    max_workers: int = 8,
+    dry_run: bool = False,
+) -> str:
+    """Upload ``local_dir`` to an HF Hub dataset repository.
+
+    The push is private by default. Creating a public repo requires
+    ``allow_public=True`` (the CLI surfaces this as ``--allow-public``)
+    so that ad-hoc redistribution of research-only sources is gated by a
+    deliberate flag.
+
+    Args:
+        local_dir: Local directory whose contents are uploaded.
+        repo_id: ``<owner>/<name>`` identifier on the Hub.
+        private: Whether to create/keep the repo private. Defaults to
+            ``True``.
+        allow_public: Companion flag for ``private=False``. Must be set
+            explicitly; otherwise the public push is refused.
+        token: Explicit Hugging Face token. When ``None``, the standard
+            resolution chain (env vars, cached token) is used.
+        revision: Git-style revision (branch, tag, or commit) to upload to.
+        commit_message: Custom commit message; defaults to
+            ``"Upload via synthpix-hf"``.
+        card_meta: Optional dataset-card metadata. When set, the README
+            is (re)generated under ``local_dir`` right before the upload.
+        include_globs: ``allow_patterns`` for ``upload_folder``.
+        ignore_globs: ``ignore_patterns`` for ``upload_folder``.
+        max_workers: Parallel upload workers.
+        dry_run: When ``True``, compare local and remote file lists, print
+            the plan, and return ``"dry-run"`` without touching the Hub.
+
+    Returns:
+        str: The commit sha returned by ``upload_folder``, or ``"dry-run"``
+            when ``dry_run`` is set.
+
+    Raises:
+        PermissionError: When ``private=False`` is requested without
+            ``allow_public=True``.
+        ValueError: When ``local_dir`` is missing/not a directory,
+            ``repo_id`` does not match the ``owner/name`` shape, or
+            ``max_workers`` is below one.
+        ImportError: If ``huggingface_hub`` is not installed.
+    """
+    if private is False and allow_public is not True:
+        raise PermissionError(_PUBLIC_GATE_MESSAGE)
+
+    local_path = Path(local_dir).expanduser()
+    _validate_local_dir(local_path)
+    _validate_repo_id(repo_id)
+    if max_workers < 1:
+        raise ValueError(f"max_workers must be >= 1, got: {max_workers}")
+
+    resolved_token = resolve_token(token)
+
+    if card_meta is not None:
+        _maybe_write_card(local_path, card_meta)
+
+    logger.info(f"Pushing {local_path} to {repo_id} (private={private})")
+
+    if dry_run:
+        return _dry_run_summary(
+            local_path,
+            repo_id,
+            revision,
+            include_globs,
+            ignore_globs,
+            resolved_token,
+        )
+
+    try:
+        hub = importlib.import_module("huggingface_hub")
+    except ImportError as exc:
+        raise ImportError(
+            "huggingface_hub is required for synthpix.hf.push_dataset; "
+            "install with `pip install synthpix[hf]`"
+        ) from exc
+
+    api = hub.HfApi(token=resolved_token)
+    api.create_repo(
+        repo_id=repo_id,
+        repo_type="dataset",
+        private=private,
+        exist_ok=True,
+    )
+
+    with enable_hf_transfer():
+        commit_info = api.upload_folder(
+            repo_id=repo_id,
+            repo_type="dataset",
+            folder_path=str(local_path),
+            revision=revision,
+            commit_message=commit_message or "Upload via synthpix-hf",
+            allow_patterns=list(include_globs),
+            ignore_patterns=list(ignore_globs),
+            num_workers=max_workers,
+        )
+
+    if isinstance(commit_info, str):
+        commit_sha = commit_info
+    else:
+        commit_sha = getattr(commit_info, "oid", None) or str(commit_info)
+
+    uploaded = _filter_local_files(local_path, include_globs, ignore_globs)
+    logger.info(f"Pushed {repo_id}@{commit_sha} with {len(uploaded)} files")
+    return commit_sha

--- a/src/synthpix/hf/push.py
+++ b/src/synthpix/hf/push.py
@@ -303,6 +303,11 @@ def push_dataset(
         exist_ok=True,
     )
 
+    # ``HfApi.upload_folder`` has no parallelism knob in huggingface_hub
+    # 1.x (the old ``num_workers`` kwarg was removed and never existed on
+    # this API). ``max_workers`` is kept on the public signature for API
+    # stability but is a no-op here; passing it to ``upload_folder`` would
+    # raise ``TypeError`` against the real Hub.
     with enable_hf_transfer():
         commit_info = api.upload_folder(
             repo_id=repo_id,
@@ -312,13 +317,17 @@ def push_dataset(
             commit_message=commit_message or "Upload via synthpix-hf",
             allow_patterns=list(include_globs),
             ignore_patterns=list(ignore_globs),
-            num_workers=max_workers,
         )
 
-    if isinstance(commit_info, str):
-        commit_sha = commit_info
+    # In huggingface_hub 1.x ``CommitInfo`` subclasses ``str`` and its
+    # string value is the *commit URL*, not the sha. Prefer the explicit
+    # ``oid`` attribute; only fall back to the string form when it is a
+    # plain ``str`` with no ``oid``.
+    oid = getattr(commit_info, "oid", None)
+    if oid:
+        commit_sha = oid
     else:
-        commit_sha = getattr(commit_info, "oid", None) or str(commit_info)
+        commit_sha = str(commit_info)
 
     uploaded = _filter_local_files(local_path, include_globs, ignore_globs)
     logger.info(f"Pushed {repo_id}@{commit_sha} with {len(uploaded)} files")

--- a/src/synthpix/hf/push.py
+++ b/src/synthpix/hf/push.py
@@ -60,6 +60,31 @@ _PUBLIC_GATE_MESSAGE = (
     "Pass allow_public=True (CLI: --allow-public) to override."
 )
 
+# Above this many selected files an ``upload_folder`` single-commit push
+# tends to fail with a Hub-side 500 on the commit endpoint. We then route
+# through ``upload_large_folder``, which commits in resumable batches.
+_DEFAULT_LARGE_FOLDER_THRESHOLD = 1000
+
+
+def _resolve_commit_sha(commit_info: object) -> str:
+    """Extract a commit sha from an ``upload_folder`` return value.
+
+    In huggingface_hub 1.x ``CommitInfo`` subclasses ``str`` and its
+    string value is the *commit URL*, not the sha. Prefer the explicit
+    ``oid`` attribute; only fall back to the string form when it is a
+    plain ``str`` with no ``oid``.
+
+    Args:
+        commit_info: The value returned by ``HfApi.upload_folder``.
+
+    Returns:
+        str: The resolved commit sha (or the stringified fallback).
+    """
+    oid = getattr(commit_info, "oid", None)
+    if oid:
+        return oid
+    return str(commit_info)
+
 
 def _validate_local_dir(local_dir: Path) -> None:
     if not local_dir.exists():
@@ -220,6 +245,8 @@ def push_dataset(
     include_globs: tuple[str, ...] = _DEFAULT_INCLUDE,
     ignore_globs: tuple[str, ...] = _DEFAULT_IGNORE,
     max_workers: int = 8,
+    large_folder: bool | None = None,
+    large_folder_threshold: int = _DEFAULT_LARGE_FOLDER_THRESHOLD,
     dry_run: bool = False,
 ) -> str:
     """Upload ``local_dir`` to an HF Hub dataset repository.
@@ -243,15 +270,27 @@ def push_dataset(
             ``"Upload via synthpix-hf"``.
         card_meta: Optional dataset-card metadata. When set, the README
             is (re)generated under ``local_dir`` right before the upload.
-        include_globs: ``allow_patterns`` for ``upload_folder``.
-        ignore_globs: ``ignore_patterns`` for ``upload_folder``.
-        max_workers: Parallel upload workers.
+        include_globs: ``allow_patterns`` for the upload.
+        ignore_globs: ``ignore_patterns`` for the upload.
+        max_workers: Parallel workers. A no-op for the single-commit
+            ``upload_folder`` path (hub 1.x has no knob there) but honored
+            by the ``upload_large_folder`` path.
+        large_folder: Tri-state selector for the upload transport.
+            ``None`` (default) auto-selects ``upload_large_folder`` when
+            the number of selected files exceeds
+            ``large_folder_threshold``; ``True``/``False`` force the large
+            or single-commit path respectively. The large path commits in
+            resumable batches and avoids the Hub-side 500 that a huge
+            single ``upload_folder`` commit triggers.
+        large_folder_threshold: Selected-file count above which the auto
+            mode switches to ``upload_large_folder``.
         dry_run: When ``True``, compare local and remote file lists, print
             the plan, and return ``"dry-run"`` without touching the Hub.
 
     Returns:
-        str: The commit sha returned by ``upload_folder``, or ``"dry-run"``
-            when ``dry_run`` is set.
+        str: The commit sha (resolved via ``dataset_info`` for the
+            ``upload_large_folder`` path, which returns no sha itself), or
+            ``"dry-run"`` when ``dry_run`` is set.
 
     Raises:
         PermissionError: When ``private=False`` is requested without
@@ -303,32 +342,52 @@ def push_dataset(
         exist_ok=True,
     )
 
-    # ``HfApi.upload_folder`` has no parallelism knob in huggingface_hub
-    # 1.x (the old ``num_workers`` kwarg was removed and never existed on
-    # this API). ``max_workers`` is kept on the public signature for API
-    # stability but is a no-op here; passing it to ``upload_folder`` would
-    # raise ``TypeError`` against the real Hub.
-    with enable_hf_transfer():
-        commit_info = api.upload_folder(
-            repo_id=repo_id,
-            repo_type="dataset",
-            folder_path=str(local_path),
-            revision=revision,
-            commit_message=commit_message or "Upload via synthpix-hf",
-            allow_patterns=list(include_globs),
-            ignore_patterns=list(ignore_globs),
-        )
-
-    # In huggingface_hub 1.x ``CommitInfo`` subclasses ``str`` and its
-    # string value is the *commit URL*, not the sha. Prefer the explicit
-    # ``oid`` attribute; only fall back to the string form when it is a
-    # plain ``str`` with no ``oid``.
-    oid = getattr(commit_info, "oid", None)
-    if oid:
-        commit_sha = oid
+    selected = _filter_local_files(local_path, include_globs, ignore_globs)
+    if large_folder is None:
+        use_large = len(selected) > large_folder_threshold
     else:
-        commit_sha = str(commit_info)
+        use_large = large_folder
 
-    uploaded = _filter_local_files(local_path, include_globs, ignore_globs)
-    logger.info(f"Pushed {repo_id}@{commit_sha} with {len(uploaded)} files")
+    if use_large:
+        # ``upload_large_folder`` commits in resumable batches (it does
+        # honor ``num_workers``) and returns ``None`` — a huge single
+        # ``upload_folder`` commit otherwise 500s on the Hub. The sha is
+        # resolved from the repo afterwards.
+        with enable_hf_transfer():
+            api.upload_large_folder(
+                repo_id=repo_id,
+                repo_type="dataset",
+                folder_path=str(local_path),
+                revision=revision,
+                private=private,
+                allow_patterns=list(include_globs),
+                ignore_patterns=list(ignore_globs),
+                num_workers=max_workers,
+                print_report=False,
+            )
+        info = api.dataset_info(repo_id, revision=revision)
+        commit_sha = getattr(info, "sha", None) or "uploaded"
+    else:
+        # ``HfApi.upload_folder`` has no parallelism knob in
+        # huggingface_hub 1.x (the old ``num_workers`` kwarg was removed
+        # and never existed on this API), so ``max_workers`` is not
+        # forwarded here; passing it would raise ``TypeError`` against
+        # the real Hub.
+        with enable_hf_transfer():
+            commit_info = api.upload_folder(
+                repo_id=repo_id,
+                repo_type="dataset",
+                folder_path=str(local_path),
+                revision=revision,
+                commit_message=commit_message or "Upload via synthpix-hf",
+                allow_patterns=list(include_globs),
+                ignore_patterns=list(ignore_globs),
+            )
+        commit_sha = _resolve_commit_sha(commit_info)
+
+    transport = "upload_large_folder" if use_large else "upload_folder"
+    logger.info(
+        f"Pushed {repo_id}@{commit_sha} with {len(selected)} files "
+        f"via {transport}"
+    )
     return commit_sha

--- a/src/synthpix/hf/push.py
+++ b/src/synthpix/hf/push.py
@@ -130,24 +130,42 @@ def _iter_relative_files(local_dir: Path) -> list[str]:
     return files
 
 
-def _matches_any(rel_path: str, patterns: tuple[str, ...]) -> bool:
+def _hub_filter_repo_objects():
+    """Return ``huggingface_hub.utils.filter_repo_objects`` or ``None``.
+
+    Reuses the same matcher that ``upload_folder`` / ``upload_large_folder``
+    consult internally, so the dry-run preview and the large-folder
+    auto-routing threshold see exactly the same file set as the real
+    upload. Falling back to an in-tree matcher would re-introduce drift
+    (e.g. ``raw_*/**`` patterns that the homegrown prefix branch silently
+    failed to honor).
+
+    Returns:
+        Callable | None: The hub helper if it imports cleanly, otherwise
+            ``None`` (older hub releases that lack the public symbol).
+    """
+    try:
+        utils_mod = importlib.import_module("huggingface_hub.utils")
+        return getattr(utils_mod, "filter_repo_objects", None)
+    except ImportError:
+        return None
+
+
+def _fallback_matches_any(rel_path: str, patterns: tuple[str, ...]) -> bool:
+    # Used only when ``huggingface_hub.utils.filter_repo_objects`` is not
+    # importable (no [hf] extra, or a very old hub). Best-effort glob
+    # semantics; for real uploads the hub matcher above is authoritative.
     for pattern in patterns:
-        # Normalize ``**`` to ``*`` for ``fnmatch`` so directory-globs match.
-        # ``fnmatch`` does not understand ``**`` natively; for our purposes
-        # ``train/**`` should match ``train/anything/deep/file.mat``.
         if fnmatchcase(rel_path, pattern):
             return True
-        # Translate ``a/**`` -> match anything below ``a/``.
         if "**" in pattern:
             translated = pattern.replace("/**", "/*").replace("**", "*")
             if fnmatchcase(rel_path, translated):
                 return True
-            # Also match arbitrary nesting: turn ``a/**`` into prefix match.
-            prefix = pattern.split("/**", 1)[0]
-            if pattern.endswith("/**") and (
-                rel_path == prefix or rel_path.startswith(prefix + "/")
-            ):
-                return True
+            if pattern.endswith("/**"):
+                prefix = pattern.split("/**", 1)[0]
+                if rel_path == prefix or rel_path.startswith(prefix + "/"):
+                    return True
     return False
 
 
@@ -156,11 +174,26 @@ def _filter_local_files(
     include_globs: tuple[str, ...],
     ignore_globs: tuple[str, ...],
 ) -> list[str]:
+    # Prefer the hub matcher so the dry-run preview and the
+    # large-folder-threshold count match what the real upload uploads.
+    filter_fn = _hub_filter_repo_objects()
+    rel_paths = _iter_relative_files(local_dir)
+
+    if filter_fn is not None:
+        selected = list(
+            filter_fn(
+                rel_paths,
+                allow_patterns=list(include_globs) if include_globs else None,
+                ignore_patterns=list(ignore_globs) if ignore_globs else None,
+            )
+        )
+        return sorted(selected)
+
     selected: list[str] = []
-    for rel in _iter_relative_files(local_dir):
-        if not _matches_any(rel, include_globs):
+    for rel in rel_paths:
+        if include_globs and not _fallback_matches_any(rel, include_globs):
             continue
-        if _matches_any(rel, ignore_globs):
+        if ignore_globs and _fallback_matches_any(rel, ignore_globs):
             continue
         selected.append(rel)
     return sorted(selected)
@@ -300,7 +333,11 @@ def push_dataset(
             ``max_workers`` is below one.
         ImportError: If ``huggingface_hub`` is not installed.
     """
-    if private is False and allow_public is not True:
+    # Use truthiness rather than identity comparison so the safety gate
+    # cannot be bypassed by a falsy non-``False`` value like ``private=0``
+    # — for a guard whose entire purpose is preventing accidental public
+    # redistribution of research-only data, ``is False`` is too narrow.
+    if not private and not allow_public:
         raise PermissionError(_PUBLIC_GATE_MESSAGE)
 
     local_path = Path(local_dir).expanduser()
@@ -311,12 +348,13 @@ def push_dataset(
 
     resolved_token = resolve_token(token)
 
-    if card_meta is not None:
-        _maybe_write_card(local_path, card_meta)
-
     logger.info(f"Pushing {local_path} to {repo_id} (private={private})")
 
     if dry_run:
+        # Dry-run must not mutate the working tree. The README write
+        # happens *after* this gate so a previewing caller (programmatic
+        # or future script ``--dry-run``) doesn't see ``local_dir/README.md``
+        # rewritten as a side effect of the preview.
         return _dry_run_summary(
             local_path,
             repo_id,
@@ -325,6 +363,9 @@ def push_dataset(
             ignore_globs,
             resolved_token,
         )
+
+    if card_meta is not None:
+        _maybe_write_card(local_path, card_meta)
 
     try:
         hub = importlib.import_module("huggingface_hub")

--- a/tests/hf/test_cli.py
+++ b/tests/hf/test_cli.py
@@ -188,12 +188,206 @@ def test_card_subcommand_respects_output(tmp_path: Path):
     assert not (tmp_path / "README.md").exists()
 
 
-def test_push_subcommand_reports_not_implemented(capsys):
-    rc = cli.main(["push"])
+def test_cli_push_requires_allow_public_when_public(
+    monkeypatch, tmp_path: Path, capsys
+):
+    monkeypatch.setattr(
+        cli, "push_dataset", lambda *a, **kw: "should-not-call"
+    )
+
+    rc = cli.main(["push", str(tmp_path), "user/repo", "--public"])
 
     captured = capsys.readouterr()
     assert rc != 0
-    assert "not yet implemented" in (captured.out + captured.err).lower()
+    assert "--allow-public" in captured.err
+
+
+def test_cli_push_public_with_allow_public_skips_tty_prompt_when_not_tty(
+    monkeypatch, tmp_path: Path
+):
+    captured: dict = {}
+
+    def _fake(local_dir, repo_id, **kwargs):
+        captured["local_dir"] = local_dir
+        captured["repo_id"] = repo_id
+        captured.update(kwargs)
+        return "sha-abc"
+
+    monkeypatch.setattr(cli, "push_dataset", _fake)
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
+
+    rc = cli.main(
+        [
+            "push",
+            str(tmp_path),
+            "user/repo",
+            "--public",
+            "--allow-public",
+        ]
+    )
+
+    assert rc == 0
+    assert captured["private"] is False
+    assert captured["allow_public"] is True
+
+
+def test_cli_push_public_prompts_on_tty(monkeypatch, tmp_path: Path):
+    calls: list[dict] = []
+
+    def _fake(local_dir, repo_id, **kwargs):
+        calls.append({"local_dir": local_dir, "repo_id": repo_id, **kwargs})
+        return "sha-abc"
+
+    monkeypatch.setattr(cli, "push_dataset", _fake)
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda *a, **kw: "yes")
+
+    rc = cli.main(
+        [
+            "push",
+            str(tmp_path),
+            "user/repo",
+            "--public",
+            "--allow-public",
+        ]
+    )
+    assert rc == 0
+    assert len(calls) == 1
+
+    monkeypatch.setattr("builtins.input", lambda *a, **kw: "no")
+    rc = cli.main(
+        [
+            "push",
+            str(tmp_path),
+            "user/repo",
+            "--public",
+            "--allow-public",
+        ]
+    )
+    assert rc != 0
+    assert len(calls) == 1
+
+
+def test_cli_push_card_partial_args_errors(
+    monkeypatch, tmp_path: Path, capsys
+):
+    monkeypatch.setattr(
+        cli, "push_dataset", lambda *a, **kw: "should-not-call"
+    )
+
+    rc = cli.main(
+        [
+            "push",
+            str(tmp_path),
+            "user/repo",
+            "--card-source-url",
+            "https://example.org",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert "card" in captured.err.lower()
+
+
+def test_cli_push_card_full_args_builds_meta(monkeypatch, tmp_path: Path):
+    captured: dict = {}
+
+    def _fake(local_dir, repo_id, **kwargs):
+        captured.update(kwargs)
+        return "sha-1"
+
+    monkeypatch.setattr(cli, "push_dataset", _fake)
+
+    rc = cli.main(
+        [
+            "push",
+            str(tmp_path),
+            "user/repo",
+            "--card-source-url",
+            "https://example.org/src",
+            "--card-citation",
+            "free-form citation",
+            "--card-name",
+            "Pretty Name",
+        ]
+    )
+
+    assert rc == 0
+    meta = captured["card_meta"]
+    assert meta is not None
+    assert meta.source_url == "https://example.org/src"
+    assert meta.citation == "free-form citation"
+    assert meta.pretty_name == "Pretty Name"
+
+
+def test_cli_push_no_card_passes_none(monkeypatch, tmp_path: Path):
+    captured: dict = {}
+
+    def _fake(local_dir, repo_id, **kwargs):
+        captured.update(kwargs)
+        return "sha-1"
+
+    monkeypatch.setattr(cli, "push_dataset", _fake)
+
+    rc = cli.main(
+        [
+            "push",
+            str(tmp_path),
+            "user/repo",
+            "--no-card",
+            "--card-source-url",
+            "https://example.org/src",
+            "--card-citation",
+            "ignored",
+        ]
+    )
+
+    assert rc == 0
+    assert captured["card_meta"] is None
+
+
+def test_cli_push_dry_run_propagates(monkeypatch, tmp_path: Path):
+    captured: dict = {}
+
+    def _fake(local_dir, repo_id, **kwargs):
+        captured.update(kwargs)
+        return "dry-run"
+
+    monkeypatch.setattr(cli, "push_dataset", _fake)
+
+    rc = cli.main(
+        ["push", str(tmp_path), "user/repo", "--dry-run"]
+    )
+
+    assert rc == 0
+    assert captured["dry_run"] is True
+
+
+def test_cli_push_token_not_logged(
+    monkeypatch, tmp_path: Path, capsys, caplog
+):
+    def _fake(local_dir, repo_id, **kwargs):
+        return "sha-secret-free"
+
+    monkeypatch.setattr(cli, "push_dataset", _fake)
+
+    rc = cli.main(
+        [
+            "push",
+            str(tmp_path),
+            "user/repo",
+            "--token",
+            "hf_secret",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "hf_secret" not in captured.out
+    assert "hf_secret" not in captured.err
+    for record in caplog.records:
+        assert "hf_secret" not in record.getMessage()
 
 
 def test_cli_pull_invokes_pull_dataset(monkeypatch, tmp_path: Path):

--- a/tests/hf/test_push.py
+++ b/tests/hf/test_push.py
@@ -1,0 +1,367 @@
+"""Tests for ``synthpix.hf.push.push_dataset``.
+
+All network access is mocked. The real ``huggingface_hub`` module is
+replaced with a stand-in that records the kwargs passed to
+``HfApi.create_repo`` and ``HfApi.upload_folder``.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from synthpix.hf import push as push_mod
+from synthpix.hf.card import DatasetCardMeta
+
+
+class _FakeCommitInfo:
+    def __init__(self, oid: str = "deadbeef") -> None:
+        self.oid = oid
+
+
+class _FakeHfApi:
+    def __init__(self, token=None, **_: object) -> None:
+        self.token = token
+        self.create_repo_calls: list[dict] = []
+        self.upload_folder_calls: list[dict] = []
+        self.list_repo_files_calls: list[dict] = []
+        self._instances_list = _FakeHfApiCollector._INSTANCES
+        self._instances_list.append(self)
+        # Configurable behaviors via class-level overrides.
+        self.list_repo_files_return: list[str] = []
+        self.list_repo_files_raises: BaseException | None = None
+        self.upload_folder_return: object = _FakeCommitInfo()
+
+    def create_repo(self, **kwargs):
+        self.create_repo_calls.append(kwargs)
+        return {"url": "https://huggingface.co/datasets/" + kwargs["repo_id"]}
+
+    def upload_folder(self, **kwargs):
+        self.upload_folder_calls.append(kwargs)
+        return self.upload_folder_return
+
+    def list_repo_files(self, repo_id, **kwargs):
+        self.list_repo_files_calls.append(
+            {"repo_id": repo_id, **kwargs}
+        )
+        if self.list_repo_files_raises is not None:
+            raise self.list_repo_files_raises
+        return list(self.list_repo_files_return)
+
+
+class _FakeHfApiCollector:
+    # Module-level shared list so tests can find the instance that
+    # ``push_dataset`` constructed.
+    _INSTANCES: list[_FakeHfApi] = []
+
+
+class _FakeRepoNotFound(Exception):
+    pass
+
+
+class _FakeErrorsModule:
+    RepositoryNotFoundError = _FakeRepoNotFound
+
+
+class _FakeHub:
+    """Minimal stand-in for ``huggingface_hub``."""
+
+    def __init__(self) -> None:
+        self.HfApi = _FakeHfApi
+        self.errors = _FakeErrorsModule
+
+
+def _install_fake_hub(monkeypatch) -> _FakeHub:
+    _FakeHfApiCollector._INSTANCES.clear()
+    fake = _FakeHub()
+    real_import_module = importlib.import_module
+
+    def _import_module(name, package=None):
+        if name == "huggingface_hub":
+            return fake
+        if name == "huggingface_hub.errors":
+            return fake.errors
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(
+        push_mod.importlib, "import_module", _import_module
+    )
+    return fake
+
+
+def _clear_env(monkeypatch) -> None:
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HF_HUB_TOKEN", raising=False)
+
+
+def _populate(local_dir: Path) -> None:
+    train = local_dir / "train"
+    train.mkdir(parents=True)
+    (train / "flow.mat").write_bytes(b"\x00" * 16)
+
+
+def test_push_basic_private(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    _populate(tmp_path)
+
+    result = push_mod.push_dataset(tmp_path, "user/repo")
+
+    [api] = _FakeHfApiCollector._INSTANCES
+    assert len(api.create_repo_calls) == 1
+    create = api.create_repo_calls[0]
+    assert create["private"] is True
+    assert create["exist_ok"] is True
+    assert create["repo_type"] == "dataset"
+    assert create["repo_id"] == "user/repo"
+
+    assert len(api.upload_folder_calls) == 1
+    up = api.upload_folder_calls[0]
+    assert up["repo_id"] == "user/repo"
+    assert up["repo_type"] == "dataset"
+    assert up["folder_path"] == str(tmp_path)
+    assert up["revision"] == "main"
+    assert up["allow_patterns"] == list(push_mod._DEFAULT_INCLUDE)
+    assert up["ignore_patterns"] == list(push_mod._DEFAULT_IGNORE)
+    assert up["commit_message"] == "Upload via synthpix-hf"
+
+    assert result == "deadbeef"
+
+
+def test_push_public_without_allow_public_raises(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    _populate(tmp_path)
+
+    with pytest.raises(PermissionError):
+        push_mod.push_dataset(tmp_path, "user/repo", private=False)
+
+    assert _FakeHfApiCollector._INSTANCES == []
+
+
+def test_push_public_with_allow_public_succeeds(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    _populate(tmp_path)
+
+    push_mod.push_dataset(
+        tmp_path, "user/repo", private=False, allow_public=True
+    )
+
+    [api] = _FakeHfApiCollector._INSTANCES
+    assert api.create_repo_calls[0]["private"] is False
+
+
+def test_push_local_dir_must_exist(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+
+    with pytest.raises(ValueError):
+        push_mod.push_dataset(tmp_path / "nope", "user/repo")
+
+
+def test_push_local_dir_must_be_directory(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    f = tmp_path / "file.txt"
+    f.write_text("x")
+
+    with pytest.raises(ValueError):
+        push_mod.push_dataset(f, "user/repo")
+
+
+def test_push_repo_id_must_have_owner_name_shape(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    _populate(tmp_path)
+
+    with pytest.raises(ValueError):
+        push_mod.push_dataset(tmp_path, "just-a-name")
+
+
+def test_push_writes_card_when_meta_provided(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    _populate(tmp_path)
+
+    meta = DatasetCardMeta(
+        name="example",
+        source_url="https://example.org/src",
+        citation="My citation",
+        pretty_name="Example Dataset",
+    )
+
+    push_mod.push_dataset(tmp_path, "user/repo", card_meta=meta)
+
+    readme = tmp_path / "README.md"
+    assert readme.exists()
+    assert "My citation" in readme.read_text()
+
+
+def test_push_card_overwrite_logs_warning(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    _populate(tmp_path)
+
+    readme = tmp_path / "README.md"
+    readme.write_text("pre-existing content")
+
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        push_mod.logger,
+        "warning",
+        lambda msg, *a, **kw: warnings.append(msg),
+    )
+
+    meta = DatasetCardMeta(
+        name="example",
+        source_url="https://example.org/src",
+        citation="My citation",
+    )
+
+    push_mod.push_dataset(tmp_path, "user/repo", card_meta=meta)
+
+    assert readme.read_text() != "pre-existing content"
+    assert any("overwriting" in w.lower() for w in warnings)
+
+
+def test_push_card_skipped_when_meta_none(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    _populate(tmp_path)
+
+    readme = tmp_path / "README.md"
+    readme.write_text("untouched content")
+
+    push_mod.push_dataset(tmp_path, "user/repo")
+
+    assert readme.read_text() == "untouched content"
+
+
+def test_push_dry_run_lists_files(monkeypatch, tmp_path, capsys):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    _populate(tmp_path)
+    # Add another file so we can assert both new + unchanged appear.
+    (tmp_path / "train" / "extra.mat").write_bytes(b"\x00" * 8)
+
+    # Configure the FakeHfApi to claim one of the local files exists remote.
+    def _factory_token(token=None, **_kwargs):
+        api = _FakeHfApi(token=token)
+        api.list_repo_files_return = ["train/flow.mat"]
+        return api
+
+    monkeypatch.setattr(
+        push_mod.importlib.import_module("huggingface_hub"),
+        "HfApi",
+        _factory_token,
+    )
+
+    result = push_mod.push_dataset(
+        tmp_path, "user/repo", dry_run=True
+    )
+
+    captured = capsys.readouterr()
+    assert result == "dry-run"
+    assert "new files: 1" in captured.out
+    assert "unchanged files: 1" in captured.out
+    # No upload_folder call was made.
+    [api] = _FakeHfApiCollector._INSTANCES
+    assert api.upload_folder_calls == []
+    assert len(api.list_repo_files_calls) == 1
+
+
+def test_push_dry_run_repo_not_found_treated_as_all_new(
+    monkeypatch, tmp_path, capsys
+):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    _populate(tmp_path)
+
+    def _factory_token(token=None, **_kwargs):
+        api = _FakeHfApi(token=token)
+        api.list_repo_files_raises = _FakeRepoNotFound("missing")
+        return api
+
+    monkeypatch.setattr(
+        push_mod.importlib.import_module("huggingface_hub"),
+        "HfApi",
+        _factory_token,
+    )
+
+    result = push_mod.push_dataset(
+        tmp_path, "user/repo", dry_run=True
+    )
+
+    captured = capsys.readouterr()
+    assert result == "dry-run"
+    assert "new files: 1" in captured.out
+    assert "unchanged files: 0" in captured.out
+
+
+def test_push_token_passes_through(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    _populate(tmp_path)
+
+    push_mod.push_dataset(tmp_path, "user/repo", token="hf_xxx")
+
+    [api] = _FakeHfApiCollector._INSTANCES
+    assert api.token == "hf_xxx"
+
+
+def test_push_token_resolved_from_env(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HF_TOKEN", "hf_env")
+    _install_fake_hub(monkeypatch)
+    _populate(tmp_path)
+
+    push_mod.push_dataset(tmp_path, "user/repo")
+
+    [api] = _FakeHfApiCollector._INSTANCES
+    assert api.token == "hf_env"
+
+
+def test_push_hf_not_installed(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    _populate(tmp_path)
+
+    def _missing(name, package=None):
+        if name == "huggingface_hub":
+            raise ImportError("no module named huggingface_hub")
+        return importlib.import_module(name, package)
+
+    monkeypatch.setattr(push_mod.importlib, "import_module", _missing)
+
+    with pytest.raises(ImportError) as excinfo:
+        push_mod.push_dataset(tmp_path, "user/repo")
+
+    assert "synthpix[hf]" in str(excinfo.value)
+
+
+def test_push_token_never_logged(monkeypatch, tmp_path, capsys, caplog):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    _populate(tmp_path)
+
+    seen_log_messages: list[str] = []
+    for level in ("info", "warning", "error", "debug"):
+        original = getattr(push_mod.logger, level)
+
+        def _spy(msg, *a, __orig=original, **kw):
+            seen_log_messages.append(str(msg))
+            return __orig(msg, *a, **kw)
+
+        monkeypatch.setattr(push_mod.logger, level, _spy)
+
+    push_mod.push_dataset(tmp_path, "user/repo", token="hf_secret")
+
+    captured = capsys.readouterr()
+    assert "hf_secret" not in captured.out
+    assert "hf_secret" not in captured.err
+    for msg in seen_log_messages:
+        assert "hf_secret" not in msg
+    for record in caplog.records:
+        assert "hf_secret" not in record.getMessage()

--- a/tests/hf/test_push.py
+++ b/tests/hf/test_push.py
@@ -8,7 +8,9 @@ replaced with a stand-in that records the kwargs passed to
 from __future__ import annotations
 
 import importlib
+import sys
 from pathlib import Path
+from typing import ClassVar
 
 import pytest
 
@@ -54,15 +56,15 @@ class _FakeHfApi:
 class _FakeHfApiCollector:
     # Module-level shared list so tests can find the instance that
     # ``push_dataset`` constructed.
-    _INSTANCES: list[_FakeHfApi] = []
+    _INSTANCES: ClassVar[list[_FakeHfApi]] = []
 
 
-class _FakeRepoNotFound(Exception):
+class _FakeRepoNotFoundError(Exception):
     pass
 
 
 class _FakeErrorsModule:
-    RepositoryNotFoundError = _FakeRepoNotFound
+    RepositoryNotFoundError = _FakeRepoNotFoundError
 
 
 class _FakeHub:
@@ -102,6 +104,72 @@ def _populate(local_dir: Path) -> None:
     (train / "flow.mat").write_bytes(b"\x00" * 16)
 
 
+def _populate_piv_tree(root: Path) -> None:
+    """Build a tree mirroring scripts/download_piv_1.py's output layout.
+
+    Splits at ``{train,val,test,tune}/<scenario>/Re####/*.mat`` plus a
+    ``splits/`` dir, a top-level README.md, and the ``raw_class1/`` /
+    ``packed_class1/`` staging dirs that must NOT be uploaded.
+    """
+    (root / "train" / "backstep" / "Re1000").mkdir(parents=True)
+    (root / "train" / "backstep" / "Re1000" / "flow_0001.mat").write_bytes(
+        b"\x00" * 8
+    )
+    (root / "train" / "cylinder").mkdir(parents=True)
+    (root / "train" / "cylinder" / "flow_0002.mat").write_bytes(b"\x00" * 8)
+    (root / "val" / "uniform").mkdir(parents=True)
+    (root / "val" / "uniform" / "flow_0003.mat").write_bytes(b"\x00" * 8)
+    (root / "test" / "DNS" / "Re3900").mkdir(parents=True)
+    (root / "test" / "DNS" / "Re3900" / "flow_0004.mat").write_bytes(
+        b"\x00" * 8
+    )
+    (root / "tune").mkdir(parents=True)
+    (root / "tune" / "flow_0005.mat").write_bytes(b"\x00" * 8)
+    (root / "splits").mkdir(parents=True)
+    (root / "splits" / "train.txt").write_text("flow_0001.mat\n")
+    (root / "splits" / "val.txt").write_text("flow_0003.mat\n")
+    (root / "README.md").write_text("# card\n")
+    # Excluded staging dirs.
+    (root / "raw_class1" / "PIV_zips").mkdir(parents=True)
+    (root / "raw_class1" / "PIV_zips" / "a.zip").write_bytes(b"PK")
+    (root / "packed_class1" / "backstep").mkdir(parents=True)
+    (root / "packed_class1" / "backstep" / "flow_0001.mat").write_bytes(
+        b"\x00"
+    )
+    # Junk that must be ignored even though it sits under a split.
+    (root / "train" / ".DS_Store").write_bytes(b"junk")
+    (root / "train" / "backstep" / "__pycache__").mkdir(parents=True)
+    (root / "train" / "backstep" / "__pycache__" / "x.pyc").write_bytes(
+        b"\x00"
+    )
+
+
+def test_filter_local_files_matches_real_piv_layout(tmp_path):
+    _populate_piv_tree(tmp_path)
+
+    selected = push_mod._filter_local_files(
+        tmp_path, push_mod._DEFAULT_INCLUDE, push_mod._DEFAULT_IGNORE
+    )
+
+    assert selected == sorted(
+        [
+            "README.md",
+            "splits/train.txt",
+            "splits/val.txt",
+            "test/DNS/Re3900/flow_0004.mat",
+            "train/backstep/Re1000/flow_0001.mat",
+            "train/cylinder/flow_0002.mat",
+            "tune/flow_0005.mat",
+            "val/uniform/flow_0003.mat",
+        ]
+    )
+    # Staging dirs and junk must never be selected.
+    assert not any(s.startswith("raw_class1/") for s in selected)
+    assert not any(s.startswith("packed_class1/") for s in selected)
+    assert not any(".DS_Store" in s for s in selected)
+    assert not any("__pycache__" in s for s in selected)
+
+
 def test_push_basic_private(monkeypatch, tmp_path):
     _clear_env(monkeypatch)
     _install_fake_hub(monkeypatch)
@@ -126,6 +194,9 @@ def test_push_basic_private(monkeypatch, tmp_path):
     assert up["allow_patterns"] == list(push_mod._DEFAULT_INCLUDE)
     assert up["ignore_patterns"] == list(push_mod._DEFAULT_IGNORE)
     assert up["commit_message"] == "Upload via synthpix-hf"
+    # hub 1.x: upload_folder has no parallelism kwarg.
+    assert "num_workers" not in up
+    assert "max_workers" not in up
 
     assert result == "deadbeef"
 
@@ -282,7 +353,7 @@ def test_push_dry_run_repo_not_found_treated_as_all_new(
 
     def _factory_token(token=None, **_kwargs):
         api = _FakeHfApi(token=token)
-        api.list_repo_files_raises = _FakeRepoNotFound("missing")
+        api.list_repo_files_raises = _FakeRepoNotFoundError("missing")
         return api
 
     monkeypatch.setattr(
@@ -328,17 +399,121 @@ def test_push_hf_not_installed(monkeypatch, tmp_path):
     _clear_env(monkeypatch)
     _populate(tmp_path)
 
+    real_import_module = importlib.import_module
+
     def _missing(name, package=None):
-        if name == "huggingface_hub":
+        if name == "huggingface_hub" or name.startswith("huggingface_hub."):
             raise ImportError("no module named huggingface_hub")
-        return importlib.import_module(name, package)
+        return real_import_module(name, package)
 
     monkeypatch.setattr(push_mod.importlib, "import_module", _missing)
+    # Also make the bare ``import huggingface_hub`` in auth._cached_token
+    # behave as if the library were absent, so token resolution degrades
+    # gracefully instead of finding the real (installed) hub.
+    monkeypatch.setitem(sys.modules, "huggingface_hub", None)
 
     with pytest.raises(ImportError) as excinfo:
         push_mod.push_dataset(tmp_path, "user/repo")
 
     assert "synthpix[hf]" in str(excinfo.value)
+
+
+class _StrictHfApi(_FakeHfApi):
+    """Like ``_FakeHfApi`` but ``upload_folder`` rejects unknown kwargs.
+
+    huggingface_hub >= 1.0's ``HfApi.upload_folder`` has NO ``num_workers``
+    parameter, so passing it raises ``TypeError`` against the real Hub.
+    This fake mirrors the real 1.x signature so the regression is caught
+    without a network call.
+    """
+
+    _ALLOWED: ClassVar[set[str]] = {
+        "repo_id",
+        "folder_path",
+        "path_in_repo",
+        "commit_message",
+        "commit_description",
+        "token",
+        "repo_type",
+        "revision",
+        "create_pr",
+        "parent_commit",
+        "allow_patterns",
+        "ignore_patterns",
+        "delete_patterns",
+        "run_as_future",
+    }
+
+    def upload_folder(self, **kwargs):
+        unexpected = set(kwargs) - self._ALLOWED
+        if unexpected:
+            raise TypeError(
+                "upload_folder() got an unexpected keyword argument "
+                f"{sorted(unexpected)[0]!r}"
+            )
+        return super().upload_folder(**kwargs)
+
+
+def _install_strict_hub(monkeypatch) -> _FakeHub:
+    fake = _install_fake_hub(monkeypatch)
+    fake.HfApi = _StrictHfApi
+    return fake
+
+
+def test_push_upload_folder_no_unsupported_kwargs(monkeypatch, tmp_path):
+    """Regression: ``num_workers`` is not a valid hub-1.x kwarg.
+
+    The old code passed ``num_workers=max_workers`` which raises
+    ``TypeError`` on the real Hub. This test uses a fake whose
+    ``upload_folder`` signature matches hub 1.x.
+    """
+    _clear_env(monkeypatch)
+    _install_strict_hub(monkeypatch)
+    _populate(tmp_path)
+
+    result = push_mod.push_dataset(tmp_path, "user/repo", max_workers=4)
+
+    [api] = _FakeHfApiCollector._INSTANCES
+    assert len(api.upload_folder_calls) == 1
+    up = api.upload_folder_calls[0]
+    assert "num_workers" not in up
+    assert "max_workers" not in up
+    assert result == "deadbeef"
+
+
+def test_push_returns_oid_not_commit_url(monkeypatch, tmp_path):
+    """Regression: hub-1.x ``CommitInfo`` is a ``str`` whose value is the
+    commit URL, not the oid.
+
+    Because ``CommitInfo`` subclasses ``str``, ``isinstance(ci, str)`` is
+    ``True``; the old branch order then returned the full commit URL
+    instead of the short commit sha.
+    """
+    _clear_env(monkeypatch)
+    fake = _install_fake_hub(monkeypatch)
+    _populate(tmp_path)
+
+    class _StrCommitInfo(str):
+        # Mirrors huggingface_hub.CommitInfo: a str whose value is the
+        # commit URL, with an ``oid`` attribute holding the sha.
+        def __new__(cls, url: str, oid: str):
+            obj = super().__new__(cls, url)
+            obj.oid = oid
+            return obj
+
+    commit_url = "https://huggingface.co/datasets/user/repo/commit/abc123sha"
+
+    def _factory(token=None, **_kwargs):
+        api = _FakeHfApi(token=token)
+        api.upload_folder_return = _StrCommitInfo(commit_url, "abc123sha")
+        return api
+
+    monkeypatch.setattr(fake, "HfApi", _factory)
+
+    result = push_mod.push_dataset(tmp_path, "user/repo")
+
+    assert result == "abc123sha"
+    assert result != commit_url
 
 
 def test_push_token_never_logged(monkeypatch, tmp_path, capsys, caplog):

--- a/tests/hf/test_push.py
+++ b/tests/hf/test_push.py
@@ -228,6 +228,23 @@ def test_push_public_without_allow_public_raises(monkeypatch, tmp_path):
     assert _FakeHfApiCollector._INSTANCES == []
 
 
+@pytest.mark.parametrize("private_value", [0, "", None])
+def test_push_safety_gate_uses_truthiness_not_identity(
+    monkeypatch, tmp_path, private_value
+):
+    # Regression: the gate must not be bypassed by a falsy-but-not-False
+    # ``private`` value (0, "", None). Identity comparison
+    # (``private is False``) would let these through.
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    _populate(tmp_path)
+
+    with pytest.raises(PermissionError):
+        push_mod.push_dataset(tmp_path, "user/repo", private=private_value)
+
+    assert _FakeHfApiCollector._INSTANCES == []
+
+
 def test_push_public_with_allow_public_succeeds(monkeypatch, tmp_path):
     _clear_env(monkeypatch)
     _install_fake_hub(monkeypatch)
@@ -285,6 +302,29 @@ def test_push_writes_card_when_meta_provided(monkeypatch, tmp_path):
     readme = tmp_path / "README.md"
     assert readme.exists()
     assert "My citation" in readme.read_text()
+
+
+def test_push_dry_run_does_not_write_card(monkeypatch, tmp_path):
+    # Regression: dry-run must not mutate the working tree. Even when
+    # ``card_meta`` is provided, ``README.md`` must not be rewritten by
+    # a previewing call.
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    _populate(tmp_path)
+    readme = tmp_path / "README.md"
+    readme.write_text("preserve-me")
+
+    meta = DatasetCardMeta(
+        name="example",
+        source_url="https://example.org/src",
+        citation="My citation",
+    )
+
+    push_mod.push_dataset(
+        tmp_path, "user/repo", card_meta=meta, dry_run=True
+    )
+
+    assert readme.read_text() == "preserve-me"
 
 
 def test_push_card_overwrite_logs_warning(monkeypatch, tmp_path):
@@ -460,6 +500,23 @@ class _StrictHfApi(_FakeHfApi):
         "run_as_future",
     }
 
+    # Verified against hub 1.15: signature is
+    #   (repo_id, folder_path, repo_type, revision, private,
+    #    allow_patterns, ignore_patterns, num_workers, print_report).
+    # Any future hub-side drift on this set will be caught without a
+    # network call.
+    _ALLOWED_LARGE: ClassVar[set[str]] = {
+        "repo_id",
+        "folder_path",
+        "repo_type",
+        "revision",
+        "private",
+        "allow_patterns",
+        "ignore_patterns",
+        "num_workers",
+        "print_report",
+    }
+
     def upload_folder(self, **kwargs):
         unexpected = set(kwargs) - self._ALLOWED
         if unexpected:
@@ -468,6 +525,15 @@ class _StrictHfApi(_FakeHfApi):
                 f"{sorted(unexpected)[0]!r}"
             )
         return super().upload_folder(**kwargs)
+
+    def upload_large_folder(self, **kwargs):
+        unexpected = set(kwargs) - self._ALLOWED_LARGE
+        if unexpected:
+            raise TypeError(
+                "upload_large_folder() got an unexpected keyword argument "
+                f"{sorted(unexpected)[0]!r}"
+            )
+        return super().upload_large_folder(**kwargs)
 
 
 def _install_strict_hub(monkeypatch) -> _FakeHub:
@@ -599,6 +665,20 @@ def test_push_force_large_uses_upload_large_folder(monkeypatch, tmp_path):
     assert api.dataset_info_calls[0]["repo_id"] == "user/repo"
     assert api.dataset_info_calls[0]["revision"] == "dev"
     assert result == "largesha0123"
+
+
+def test_push_upload_large_folder_no_unsupported_kwargs(
+    monkeypatch, tmp_path
+):
+    # Regression guard for the path a real PIV class-1 push (>1000 files)
+    # actually takes via auto-routing. ``_StrictHfApi.upload_large_folder``
+    # mirrors the hub-1.15 signature, so any future hub-side drift on this
+    # surface is caught without a network call.
+    _clear_env(monkeypatch)
+    _install_strict_hub(monkeypatch)
+    _populate(tmp_path)
+
+    push_mod.push_dataset(tmp_path, "user/repo", large_folder=True)
 
 
 def test_push_auto_routes_large_by_threshold(monkeypatch, tmp_path):

--- a/tests/hf/test_push.py
+++ b/tests/hf/test_push.py
@@ -23,6 +23,11 @@ class _FakeCommitInfo:
         self.oid = oid
 
 
+class _FakeDatasetInfo:
+    def __init__(self, sha: str = "largesha0123") -> None:
+        self.sha = sha
+
+
 class _FakeHfApi:
     def __init__(self, token=None, **_: object) -> None:
         self.token = token
@@ -35,6 +40,9 @@ class _FakeHfApi:
         self.list_repo_files_return: list[str] = []
         self.list_repo_files_raises: BaseException | None = None
         self.upload_folder_return: object = _FakeCommitInfo()
+        self.upload_large_folder_calls: list[dict] = []
+        self.dataset_info_calls: list[dict] = []
+        self.dataset_info_return: object = _FakeDatasetInfo()
 
     def create_repo(self, **kwargs):
         self.create_repo_calls.append(kwargs)
@@ -43,6 +51,14 @@ class _FakeHfApi:
     def upload_folder(self, **kwargs):
         self.upload_folder_calls.append(kwargs)
         return self.upload_folder_return
+
+    def upload_large_folder(self, **kwargs):
+        self.upload_large_folder_calls.append(kwargs)
+        return None
+
+    def dataset_info(self, repo_id, **kwargs):
+        self.dataset_info_calls.append({"repo_id": repo_id, **kwargs})
+        return self.dataset_info_return
 
     def list_repo_files(self, repo_id, **kwargs):
         self.list_repo_files_calls.append(
@@ -540,3 +556,92 @@ def test_push_token_never_logged(monkeypatch, tmp_path, capsys, caplog):
         assert "hf_secret" not in msg
     for record in caplog.records:
         assert "hf_secret" not in record.getMessage()
+
+
+# --- large-folder transport routing -------------------------------------
+
+
+def test_push_small_uses_upload_folder(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    _populate(tmp_path)  # single file, well under the threshold
+
+    result = push_mod.push_dataset(tmp_path, "user/repo")
+
+    [api] = _FakeHfApiCollector._INSTANCES
+    assert len(api.upload_folder_calls) == 1
+    assert api.upload_large_folder_calls == []
+    assert result == "deadbeef"  # oid from _FakeCommitInfo
+
+
+def test_push_force_large_uses_upload_large_folder(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    _populate(tmp_path)
+
+    result = push_mod.push_dataset(
+        tmp_path, "user/repo", revision="dev", large_folder=True
+    )
+
+    [api] = _FakeHfApiCollector._INSTANCES
+    assert api.upload_folder_calls == []
+    assert len(api.upload_large_folder_calls) == 1
+    call = api.upload_large_folder_calls[0]
+    # upload_large_folder has no commit_message; it does take num_workers.
+    assert "commit_message" not in call
+    assert call["num_workers"] == 8
+    assert call["repo_type"] == "dataset"
+    assert call["revision"] == "dev"
+    assert call["print_report"] is False
+    assert isinstance(call["allow_patterns"], list)
+    assert isinstance(call["ignore_patterns"], list)
+    # upload_large_folder returns None -> sha resolved via dataset_info.
+    assert api.dataset_info_calls[0]["repo_id"] == "user/repo"
+    assert api.dataset_info_calls[0]["revision"] == "dev"
+    assert result == "largesha0123"
+
+
+def test_push_auto_routes_large_by_threshold(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    _populate_piv_tree(tmp_path)  # 8 selected files
+
+    push_mod.push_dataset(
+        tmp_path, "user/repo", large_folder_threshold=2
+    )
+
+    [api] = _FakeHfApiCollector._INSTANCES
+    assert api.upload_folder_calls == []
+    assert len(api.upload_large_folder_calls) == 1
+
+
+def test_push_force_small_overrides_threshold(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    _populate_piv_tree(tmp_path)
+
+    push_mod.push_dataset(
+        tmp_path,
+        "user/repo",
+        large_folder=False,
+        large_folder_threshold=0,
+    )
+
+    [api] = _FakeHfApiCollector._INSTANCES
+    assert len(api.upload_folder_calls) == 1
+    assert api.upload_large_folder_calls == []
+
+
+def test_push_dry_run_unaffected_by_large_folder(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    _install_fake_hub(monkeypatch)
+    _populate(tmp_path)
+
+    result = push_mod.push_dataset(
+        tmp_path, "user/repo", large_folder=True, dry_run=True
+    )
+
+    [api] = _FakeHfApiCollector._INSTANCES
+    assert result == "dry-run"
+    assert api.upload_folder_calls == []
+    assert api.upload_large_folder_calls == []

--- a/tests/hf/test_push_live.py
+++ b/tests/hf/test_push_live.py
@@ -1,0 +1,97 @@
+"""Live, network-touching tests for ``synthpix.hf.push_dataset``.
+
+Skipped by default. To run, set ``HF_TOKEN`` in the environment and pass
+``--run-hf-live`` on the pytest command line, e.g.::
+
+    HF_TOKEN=hf_xxx uv run pytest tests/hf/test_push_live.py \
+        -m hf_live --run-hf-live
+
+The test pushes a tiny fixture to a unique private repo derived from
+the authenticated user, pulls it back, asserts byte equality, and
+cleans up the repo in a finalizer.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime
+
+import h5py
+import numpy as np
+import pytest
+
+
+@pytest.mark.hf_live
+def test_push_dataset_live_roundtrip(tmp_path, request):
+    if not request.config.getoption("--run-hf-live", default=False):
+        pytest.skip("requires --run-hf-live")
+    token = os.environ.get("HF_TOKEN")
+    if not token:
+        pytest.skip("requires HF_TOKEN in env")
+
+    try:
+        from huggingface_hub import HfApi
+    except ImportError:
+        pytest.skip("huggingface_hub is not installed")
+
+    api = HfApi(token=token)
+    try:
+        username = api.whoami()["name"]
+    except Exception as exc:
+        pytest.skip(f"could not resolve username via whoami(): {exc}")
+
+    repo_id = f"{username}/synthpix-ci-push-{uuid.uuid4().hex[:8]}"
+
+    # Build a tiny train/flow_0001.mat fixture with a MATLAB v7.3 header.
+    train = tmp_path / "src" / "train"
+    train.mkdir(parents=True)
+    mat_path = train / "flow_0001.mat"
+    h = w = 8
+    with h5py.File(mat_path, "w", libver="latest", userblock_size=512) as f:
+        f.create_dataset(
+            "I0",
+            data=np.random.randint(0, 255, size=(h, w), dtype=np.uint8),
+        )
+        f.create_dataset(
+            "I1",
+            data=np.random.randint(0, 255, size=(h, w), dtype=np.uint8),
+        )
+        f.create_dataset(
+            "V", data=np.random.rand(h, w, 2).astype(np.float32)
+        )
+    header = (
+        f"MATLAB 7.3 MAT-file, Platform: Python-h5py, "
+        f"Created on {datetime.now():%c}"
+    ).encode("ascii").ljust(116, b" ")
+    header += b" " * (512 - 116)
+    with open(mat_path, "r+b") as fp:
+        fp.write(header)
+
+    original_bytes = mat_path.read_bytes()
+
+    def _cleanup():
+        try:
+            api.delete_repo(
+                repo_id=repo_id, repo_type="dataset", missing_ok=True
+            )
+        except Exception:
+            pass
+
+    request.addfinalizer(_cleanup)
+
+    from synthpix.hf import pull_dataset, push_dataset
+
+    push_dataset(
+        tmp_path / "src",
+        repo_id,
+        private=True,
+        token=token,
+    )
+
+    dst = tmp_path / "dst"
+    pull_dataset(repo_id, dst, token=token)
+
+    pulled = dst / "train" / "flow_0001.mat"
+    assert pulled.exists(), f"pulled file missing: {pulled}"
+    assert pulled.read_bytes() == original_bytes

--- a/tests/scripts/test_download_piv_push_flag.py
+++ b/tests/scripts/test_download_piv_push_flag.py
@@ -1,0 +1,147 @@
+"""Tests for the ``--push-to`` opt-in flag on ``scripts/download_piv_1.py``.
+
+The download/convert/split steps are short-circuited so that no Google
+Drive traffic occurs. ``synthpix.hf.push_dataset`` is patched to a
+recording stub.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "download_piv_1.py"
+
+
+def _load_script_module() -> ModuleType:
+    """Import ``download_piv_1.py`` as a module without running ``__main__``.
+
+    The script lives under ``scripts/`` and imports a sibling ``utils``
+    module via ``from utils import ...``; we therefore add the script's
+    parent directory to ``sys.path`` before loading.
+
+    Returns:
+        ModuleType: The loaded module object.
+    """
+    scripts_dir = str(_SCRIPT_PATH.parent)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+
+    spec = importlib.util.spec_from_file_location(
+        "download_piv_1_test", _SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def script() -> ModuleType:
+    try:
+        return _load_script_module()
+    except ImportError as exc:
+        pytest.skip(f"download_piv_1 deps not installed: {exc}")
+
+
+def _make_args(**overrides):
+    base = dict(
+        push_to=None,
+        push_private=True,
+        push_public=False,
+        allow_public=False,
+        push_token=None,
+        no_push_card=False,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def test_maybe_push_no_op_without_push_to(monkeypatch, script, tmp_path):
+    called: list = []
+
+    def _spy(*args, **kwargs):
+        called.append((args, kwargs))
+        return "sha"
+
+    # Patch the push_dataset symbol accessed via ``from synthpix.hf import ...``
+    # at call time. We replace the attribute on the imported ``synthpix.hf``
+    # package so the lazy import inside ``_maybe_push`` picks up the spy.
+    import synthpix.hf as hf_pkg
+
+    monkeypatch.setattr(hf_pkg, "push_dataset", _spy)
+
+    args = _make_args()
+    script._maybe_push(args, tmp_path)
+
+    assert called == []
+
+
+def test_maybe_push_invokes_push_dataset_with_card(
+    monkeypatch, script, tmp_path
+):
+    captured: dict = {}
+
+    def _spy(*, local_dir, repo_id, **kwargs):
+        captured["local_dir"] = local_dir
+        captured["repo_id"] = repo_id
+        captured.update(kwargs)
+        return "sha-123"
+
+    import synthpix.hf as hf_pkg
+
+    monkeypatch.setattr(hf_pkg, "push_dataset", _spy)
+
+    args = _make_args(push_to="user/my-piv")
+    script._maybe_push(args, tmp_path)
+
+    assert captured["repo_id"] == "user/my-piv"
+    assert captured["local_dir"] == tmp_path
+    meta = captured["card_meta"]
+    assert meta is not None
+    assert meta.source_url == script._PUSH_SOURCE_URL
+    assert "Dense motion estimation" in meta.citation
+
+
+def test_maybe_push_no_card_passes_none(monkeypatch, script, tmp_path):
+    captured: dict = {}
+
+    def _spy(*, local_dir, repo_id, **kwargs):
+        captured.update(kwargs)
+        return "sha"
+
+    import synthpix.hf as hf_pkg
+
+    monkeypatch.setattr(hf_pkg, "push_dataset", _spy)
+
+    args = _make_args(push_to="user/my-piv", no_push_card=True)
+    script._maybe_push(args, tmp_path)
+
+    assert captured["card_meta"] is None
+
+
+def test_push_public_requires_allow_public_exits_nonzero(tmp_path):
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT_PATH),
+            "--out-dir",
+            str(out_dir),
+            "--push-to",
+            "user/repo",
+            "--push-public",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+    assert "--allow-public" in proc.stderr

--- a/tests/scripts/test_download_piv_push_flag.py
+++ b/tests/scripts/test_download_piv_push_flag.py
@@ -54,7 +54,6 @@ def script() -> ModuleType:
 def _make_args(**overrides):
     base = dict(
         push_to=None,
-        push_private=True,
         push_public=False,
         allow_public=False,
         push_token=None,


### PR DESCRIPTION
> **Stacked on PR #259** (`feat/hf-pull-dataset`) which is stacked on PR #258 (`feat/huggingface-integration`). When those land on `dev`, this PR's base will auto-update.

## Summary

PR3 of 5 for Hugging Face Hub integration in synthpix. Adds the **upload side** of the integration — `push_dataset()`, `synthpix-hf push` CLI subcommand, and a `--push-to REPO_ID` flag on `scripts/download_piv_{1,2}.py` so the pipeline can ship straight to the Hub.

Combined with PRs #258 and #259, this completes the round-trip: a built local dataset → HF Hub → any compute that pulls it. Once this merges (and your colleague pushes), the PIV class-1 dataset becomes accessible from Lambda, Kaggle, laptops, anything with an HF token.

## Safety: default-private with a double safety gate

The PIV class-1 source is "research only / all rights reserved" per the upstream authors. Accidental public push is the failure mode this PR is designed to prevent:

- `private=True` is the default in both `push_dataset()` and the CLI.
- Public push requires **both** `--public` AND `--allow-public` flags; passing `--public` alone fails parse with stderr explaining the gate.
- On an interactive TTY, `--public --allow-public` also prompts `Refusing to push public unless you type 'yes': ` and only proceeds on exact `yes`.
- In non-TTY contexts (CI / piped) the prompt is skipped — `--allow-public` is the deliberate friction; we don't want to deadlock pipelines.
- The same gate applies to `--push-public` on `scripts/download_piv_{1,2}.py`.

## What this PR adds

| Module | Purpose |
|---|---|
| `src/synthpix/hf/push.py` | `push_dataset(local_dir, repo_id, *, private=True, allow_public=False, token=None, revision="main", commit_message=None, card_meta=None, include_globs=..., ignore_globs=..., max_workers=8, dry_run=False) -> str` (commit sha). Lazy-imports `huggingface_hub`. Argument validation (path/repo_id shape) and the public-safety gate run **before** any network call. Optionally writes a `DatasetCardMeta`-rendered `README.md` into `local_dir` before upload so the card travels in the same commit. `dry_run=True` calls `list_repo_files` (gracefully handles `RepositoryNotFoundError` as "all new") and prints a planned-diff summary without uploading. |
| `src/synthpix/hf/cli.py` | `synthpix-hf push LOCAL_DIR REPO_ID [...]` — all the surface area: `--public`/`--allow-public`, `--token`, `--revision`, `--commit-message`, `--no-card`, `--card-{name,source-url,citation}`, `--include`/`--ignore`, `--max-workers`, `--dry-run`. Token is never logged or printed. |
| `scripts/download_piv_1.py` + `download_piv_2.py` | Opt-in `--push-to REPO_ID` plus companion `--push-private`/`--push-public`/`--allow-public`/`--push-token`/`--no-push-card` flags. When set, runs `push_dataset` after `perform_split` with a default class-specific `DatasetCardMeta` (source URL = the GitHub repo, citation = the Exp Fluids 2019 paper). Lazy-imports `synthpix.hf`, so missing `[hf]` extra doesn't break the download flow if `--push-to` isn't used. |

## Tests

- `tests/hf/test_push.py` — **15 mocked tests** covering: basic private/public paths, all argument validation (path-must-exist, path-must-be-dir, repo_id shape), card-writing behavior (overwrites with warning when content differs; left alone when `card_meta=None`), `dry_run` (with and without an existing repo), token plumbing (explicit, env-resolved, never-logged), `ImportError` when `huggingface_hub` not installed, and the explicit `PermissionError` from the safety gate (with assertion that `create_repo` was NOT called).
- `tests/hf/test_cli.py` (extended) — **8 new tests**: `--public` without `--allow-public` exit-non-zero, TTY-vs-non-TTY confirmation paths, partial card-flag validation, `--no-card`, `--dry-run` propagation, token-never-logged.
- `tests/hf/test_push_live.py` — gated by `@pytest.mark.hf_live` + `--run-hf-live`, requires `HF_TOKEN`. Creates a unique private repo via `HfApi.whoami()`, pushes a tiny `.mat` fixture, pulls it back via `pull_dataset`, asserts byte equality, finalizer deletes the repo even on assertion failure.
- `tests/scripts/test_download_piv_push_flag.py` — 4 tests covering the `--push-to` flag on `download_piv_1.py`: not-called when flag absent, called with the right meta when present, `card_meta=None` when `--no-push-card`, and `--push-public` without `--allow-public` exits before pushing.

**Local result:** `uv run pytest tests/hf/ tests/scripts/ -v` → **69 passed, 2 skipped, 1 failed**. The 1 failure is the same pre-existing PR1 `HfFolder` issue tracked in PR #258's review; PR3 is explicitly out-of-scope for that fix.

## Inherited heads-ups (carried from PR2)

- `huggingface_hub` v1.x changed `CommitInfo` shape. `push_dataset` defends with `getattr(commit_info, "oid", commit_info)` so the return is always a string-like sha.
- `RepositoryNotFoundError` moved between `huggingface_hub.errors` and `huggingface_hub.utils` across releases. `_dry_run_summary` imports both names defensively.

## Behavior change (intentional)

- `scripts/download_piv_{1,2}.py`: `fetch_splits` / `main` / `_maybe_push` are no longer wrapped by the broad `try/except Exception` that previously caught split-ratio parse errors. Real failures in fetch/build/push now surface with their own traceback instead of being relabelled `"Split ratio is in the wrong format"`. The narrow `try/except` around `parse_split_ratio` is preserved, so the original UX for that specific input error is unchanged. Recorded here per review follow-up on `download_piv_1.py:651`.

## Out of scope (deferred)

- The `hf://` URI resolver in `data_sources/` — PR5 (stretch)
- Docs (`docs/hf_integration.md`) — PR4
- Fixing the `HfFolder` removal in `auth.py` — belongs in PR1's review-response

## Test plan

- [x] Local: `uv run pytest tests/hf/ tests/scripts/ -v` — 69 passed (1 pre-existing failure inherited from PR1)
- [x] Local: `uv run pre-commit run --files <touched>` + `--hook-stage push` — clean on all touched files
- [x] Local: `synthpix-hf push --help` exits cleanly with the full flag surface
- [ ] CI on stacked base
- [ ] Real-world: actual push of the PIV class-1 dataset to a private HF repo (will happen in parallel from the local branch — does not need this PR merged first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
