### PR TITLE
ci: run commit-lint on pull_request instead of push

### DIFF
--- a/.github/workflows/commit-lint.yaml
+++ b/.github/workflows/commit-lint.yaml
@@ -2,9 +2,11 @@ name: Commit style validation
 
 on:
     workflow_dispatch:
-    push:
-        branches:
-            - '**'
+    # Validate commit messages on pull requests (wagoid lints the base..head
+    # range). Running on `push` instead made merges to main fail, because a
+    # merge's push range re-lints already-merged history rather than just the
+    # new commits.
+    pull_request:
 
 jobs:
   commit-lint:


### PR DESCRIPTION
## What
Switch the `Commit style validation` workflow trigger from `push: ['**']` to `pull_request`.

## Why
After #263 merged, commit-lint **failed on the `main` push**: on a `push` event wagoid re-lints the entire incoming commit range, so a merge re-checks already-merged history and trips on any non-conventional commit. On `pull_request` it lints only the PR's `base..head` commits — the actual gate — and never runs on the post-merge push to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)