### PR TITLE
ci: sync dev -> main (commit-lint on pull_request)

### DIFF
--- a/.github/workflows/commit-lint.yaml
+++ b/.github/workflows/commit-lint.yaml
@@ -2,9 +2,11 @@ name: Commit style validation
 
 on:
     workflow_dispatch:
-    push:
-        branches:
-            - '**'
+    # Validate commit messages on pull requests (wagoid lints the base..head
+    # range). Running on `push` instead made merges to main fail, because a
+    # merge's push range re-lints already-merged history rather than just the
+    # new commits.
+    pull_request:
 
 jobs:
   commit-lint:


### PR DESCRIPTION
Brings the commit-lint trigger fix (#265) from `dev` into `main`, keeping the two branches in sync.

- `Commit style validation` now runs on `pull_request` instead of `push`, so it no longer fails on the post-merge push to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)